### PR TITLE
Add pre prod delivery bridges

### DIFF
--- a/kube-config-files/cms-kafka-bridge-pre-prod.yaml
+++ b/kube-config-files/cms-kafka-bridge-pre-prod.yaml
@@ -1,36 +1,36 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: cms-metadata-kafka-bridge-pub-pre-prod
+  name: cms-kafka-bridge-pre-prod
   labels:
-    app: cms-metadata-kafka-bridge-pub-pre-prod
+    app: cms-kafka-bridge-pre-prod
     visualize: "true"
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: cms-metadata-kafka-bridge-pub-pre-prod
+      app: cms-kafka-bridge-pre-prod
   template:
     metadata:
       labels:
-        app: cms-metadata-kafka-bridge-pub-pre-prod
+        app: cms-kafka-bridge-pre-prod
         visualize: "true"
     spec:
       containers:
-      - name: cms-metadata-kafka-bridge-pub-pre-prod
+      - name: cms-kafka-bridge-pre-prod
         image:  coco/coco-kafka-bridge:v14.0.1
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: certificates-storage
         env:
         - name: QUEUE_PROXY_ADDRS
-          value: "https://pub-pre-prod-uk-up.ft.com/__kafka-rest-proxy"
+          value: "https://pre-prod-uk-up.ft.com/__kafka-rest-proxy"
         - name: GROUP_ID
-          value: "k8s-metadata-kafka-bridge-pub-xp"
+          value: "k8s-kafka-bridge-pre-prod"
         - name: CONSUMER_AUTOCOMMIT_ENABLE
-          value: "true"
+          value: "false"
         - name: TOPIC
-          value: "NativeCmsMetadataPublicationEvents"
+          value: "NativeCmsPublicationEvents"
         - name: PRODUCER_HOST
           value: "http://kafka:8082"
         - name: PRODUCER_HOST_HEADER
@@ -40,8 +40,8 @@ spec:
         - name: AUTHORIZATION_KEY
           valueFrom:
             secretKeyRef:
-              name: pub-auth
-              key: pub-pre-prod-auth
+              name: delivery-auth
+              key: pre-prod-uk
         ports:
         - containerPort: 8080
         livenessProbe:
@@ -58,17 +58,17 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: cms-metadata-kafka-bridge-pub-pre-prod
+  name: cms-kafka-bridge-pre-prod
   labels:
-    app: cms-metadata-kafka-bridge-pub-pre-prod
+    app: cms-kafka-bridge-pre-prod
     visualize: "true"
     hasHealthcheck: "true"
     healthcheckSeverity: warning
 spec:
   ports:
     - port: 8080
-      name: "cms-metadata-kafka-bridge-pub-pre-prod"
+      name: "cms-kafka-bridge-pre-prod"
       targetPort: 8080
   selector:
-    app: cms-metadata-kafka-bridge-pub-pre-prod
+    app: cms-kafka-bridge-pre-prod
 

--- a/kube-config-files/cms-kafka-bridge-pre-prod.yaml
+++ b/kube-config-files/cms-kafka-bridge-pre-prod.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: cms-kafka-bridge-pre-prod
-        image:  coco/coco-kafka-bridge:v14.0.1
+        image:  coco/coco-kafka-bridge:remove-host-based-routing
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: certificates-storage
@@ -26,9 +26,9 @@ spec:
         - name: QUEUE_PROXY_ADDRS
           value: "https://pre-prod-uk-up.ft.com/__kafka-rest-proxy"
         - name: GROUP_ID
-          value: "k8s-kafka-bridge-pre-prod"
+          value: "k8s-kafka-bridge-pre-prod-1"
         - name: CONSUMER_AUTOCOMMIT_ENABLE
-          value: "false"
+          value: "true"
         - name: TOPIC
           value: "NativeCmsPublicationEvents"
         - name: PRODUCER_HOST

--- a/kube-config-files/cms-metadata-kafka-bridge-pre-prod.yaml
+++ b/kube-config-files/cms-metadata-kafka-bridge-pre-prod.yaml
@@ -1,36 +1,36 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: cms-kafka-bridge-pub-xp
+  name: cms-metadata-kafka-bridge-pre-prod
   labels:
-    app: cms-kafka-bridge-pub-xp
+    app: cms-metadata-kafka-bridge-pre-prod
     visualize: "true"
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: cms-kafka-bridge-pub-xp
+      app: cms-metadata-kafka-bridge-pre-prod
   template:
     metadata:
       labels:
-        app: cms-kafka-bridge-pub-xp
+        app: cms-metadata-kafka-bridge-pre-prod
         visualize: "true"
     spec:
       containers:
-      - name: cms-kafka-bridge-pub-xp
+      - name: cms-metadata-kafka-bridge-pre-prod
         image:  coco/coco-kafka-bridge:v14.0.1
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: certificates-storage
         env:
         - name: QUEUE_PROXY_ADDRS
-          value: "https://pub-xp-up.ft.com/__kafka-rest-proxy"
+          value: "https://pre-prod-uk-up.ft.com/__kafka-rest-proxy"
         - name: GROUP_ID
-          value: "k8s-kafka-bridge-pub-xp"
+          value: "k8s-metadata-kafka-bridge-pre-prod"
         - name: CONSUMER_AUTOCOMMIT_ENABLE
-          value: "false"
+          value: "true"
         - name: TOPIC
-          value: "NativeCmsPublicationEvents"
+          value: "NativeCmsMetadataPublicationEvents"
         - name: PRODUCER_HOST
           value: "http://kafka:8082"
         - name: PRODUCER_HOST_HEADER
@@ -40,8 +40,8 @@ spec:
         - name: AUTHORIZATION_KEY
           valueFrom:
             secretKeyRef:
-              name: pub-auth
-              key: pub-xp-auth
+              name: delivery-auth
+              key: pre-prod-uk
         ports:
         - containerPort: 8080
         livenessProbe:
@@ -58,17 +58,17 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: cms-kafka-bridge-pub-xp
+  name: cms-metadata-kafka-bridge-pre-prod
   labels:
-    app: cms-kafka-bridge-pub-xp
+    app: cms-metadata-kafka-bridge-pre-prod
     visualize: "true"
     hasHealthcheck: "true"
     healthcheckSeverity: warning
 spec:
   ports:
     - port: 8080
-      name: "cms-kafka-bridge-pub-xp"
+      name: "cms-metadata-kafka-bridge-pre-prod"
       targetPort: 8080
   selector:
-    app: cms-kafka-bridge-pub-xp
+    app: cms-metadata-kafka-bridge-pre-prod
 

--- a/kube-config-files/cms-metadata-kafka-bridge-pre-prod.yaml
+++ b/kube-config-files/cms-metadata-kafka-bridge-pre-prod.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: cms-metadata-kafka-bridge-pre-prod
-        image:  coco/coco-kafka-bridge:v14.0.1
+        image:  coco/coco-kafka-bridge:remove-host-based-routing
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: certificates-storage


### PR DESCRIPTION
- known issue: the bridges forward some messages several times because it's going to the delivery cluster, which has caching enabled. All other bridges use the pub cluster, which has caching disabled