### PR TITLE
Added configuration so that jounald will not discard images.

### DIFF
--- a/userdata/cloud-config-worker
+++ b/userdata/cloud-config-worker
@@ -321,6 +321,13 @@ coreos:
 {{end}}
 
 write_files:
+  - path: /etc/systemd/journald.conf.d/10-override-config.conf
+    content: |
+      [Journal]
+      MaxLevelConsole=crit
+      Compress=false
+      RateLimitInterval=0
+      RateLimitBurst=0
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |
       DOCKER_OPT_BIP=""


### PR DESCRIPTION
This commit is based on the one Euan made on the old cluster: https://github.com/Financial-Times/coco-provisioner/blob/master/ansible/userdata/default_instance_user_data.yaml#L161-L167