### PR TITLE
Extract global configs

### DIFF
--- a/kube-config-files/alphaville-series-rw-neo4j-red.yaml
+++ b/kube-config-files/alphaville-series-rw-neo4j-red.yaml
@@ -25,7 +25,10 @@ spec:
             memory: 256Mi
         env:
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.alphaville-series-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/alphaville-series-rw-neo4j-red.yaml
+++ b/kube-config-files/alphaville-series-rw-neo4j-red.yaml
@@ -37,7 +37,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort:  8080
         livenessProbe:

--- a/kube-config-files/alphaville-series-rw-neo4j-red.yaml
+++ b/kube-config-files/alphaville-series-rw-neo4j-red.yaml
@@ -32,7 +32,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.alphaville-series-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/api-policy-component.yaml
+++ b/kube-config-files/api-policy-component.yaml
@@ -37,7 +37,7 @@ spec:
         - name: JERSEY_TIMEOUT_DURATION
           value: "10000ms"
         - name: GRAPHITE_PREFIX
-          value: "coco.services.test-kube.api-policy-component.%i"
+          value: "coco.services.k8s.api-policy-component"
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/api-policy-component.yaml
+++ b/kube-config-files/api-policy-component.yaml
@@ -6,7 +6,7 @@ metadata:
     app: api-policy-component
     visualize: "true"
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: api-policy-component
@@ -23,11 +23,17 @@ spec:
         - name: JAVA_OPTS
           value: "-Xms384m -Xmx384m -XX:+UseG1GC -server"
         - name: GRAPHITE_HOST
-          value: "graphite.ft.com"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.host
+        - name: GRAPHITE_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.port
         - name: READ_ENDPOINT
           value: "path-routing-varnish:80"
-        - name: GRAPHITE_PORT
-          value: "2003"
         - name: JERSEY_TIMEOUT_DURATION
           value: "10000ms"
         - name: GRAPHITE_PREFIX

--- a/kube-config-files/binary-ingester.yaml
+++ b/kube-config-files/binary-ingester.yaml
@@ -67,9 +67,15 @@ spec:
         - name: WRITER_URL
           value: "binary-writer:8080"
         - name: ZOOKEEPER_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.host
         - name: ZOOKEEPER_PORT
-          value: "2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.port
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/binary-ingester.yaml
+++ b/kube-config-files/binary-ingester.yaml
@@ -60,7 +60,10 @@ spec:
         - name: FORWARD_TO_TOPIC_NAME
           value: "PostPublicationEvents"
         - name: KAFKA_PROXY
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: WRITER_URL
           value: "binary-writer:8080"
         - name: ZOOKEEPER_HOST

--- a/kube-config-files/binary-ingester.yaml
+++ b/kube-config-files/binary-ingester.yaml
@@ -30,9 +30,15 @@ spec:
         - name: ADMIN_PORT
           value: "8081"
         - name: KAFKA_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.host
         - name: KAFKA_PORT
-          value: "9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.port
         - name: KAFKA_GROUPNAME
           value: "BinaryIngester"
         - name: KAFKA_SYSTEM_ID

--- a/kube-config-files/binary-writer.yaml
+++ b/kube-config-files/binary-writer.yaml
@@ -23,9 +23,15 @@ spec:
         - name: JAVA_OPTS
           value: "-Xms296m -Xmx296m -XX:+UseG1GC -server"
         - name: KAFKA_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.host
         - name: KAFKA_PORT
-          value: "9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.port
         - name: BUCKET_PATH
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/brands-rw-neo4j-red.yaml
+++ b/kube-config-files/brands-rw-neo4j-red.yaml
@@ -34,7 +34,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.brands-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/brands-rw-neo4j-red.yaml
+++ b/kube-config-files/brands-rw-neo4j-red.yaml
@@ -27,7 +27,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.brands-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/brands-rw-neo4j-red.yaml
+++ b/kube-config-files/brands-rw-neo4j-red.yaml
@@ -39,7 +39,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/brightcove-annotations-rw-red.yaml
+++ b/kube-config-files/brightcove-annotations-rw-red.yaml
@@ -37,7 +37,10 @@ spec:
         - name: PLATFORM_VERSION
           value: "brightcove"
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         - name: BATCH_SIZE
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/brightcove-annotations-rw-red.yaml
+++ b/kube-config-files/brightcove-annotations-rw-red.yaml
@@ -39,7 +39,10 @@ spec:
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: GRAPHITE_ADDRESS
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/brightcove-annotations-rw-red.yaml
+++ b/kube-config-files/brightcove-annotations-rw-red.yaml
@@ -49,7 +49,7 @@ spec:
               name: global-config
               key: graphite.address
         - name: GRAPHITE_PREFIX
-          value: "coco.services.k8s-test.v1-annotations-rw-neo4j-red"
+          value: "coco.services.k8s.v1-annotations-rw-neo4j-red"
         - name: LOG_METRICS
           value: "false"
         - name: APP_PORT

--- a/kube-config-files/brightcove-annotations-rw-red.yaml
+++ b/kube-config-files/brightcove-annotations-rw-red.yaml
@@ -41,7 +41,10 @@ spec:
         - name: BATCH_SIZE
           value: "50"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s-test.v1-annotations-rw-neo4j-red"
         - name: LOG_METRICS

--- a/kube-config-files/cms-kafka-bridge-pub-pre-prod.yaml
+++ b/kube-config-files/cms-kafka-bridge-pub-pre-prod.yaml
@@ -32,7 +32,10 @@ spec:
         - name: TOPIC
           value: "NativeCmsPublicationEvents"
         - name: PRODUCER_HOST
-          value: "http://kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: PRODUCER_HOST_HEADER
           value: "kafka-proxy"
         - name: PRODUCER_TYPE

--- a/kube-config-files/cms-metadata-kafka-bridge-pub-pre-prod.yaml
+++ b/kube-config-files/cms-metadata-kafka-bridge-pub-pre-prod.yaml
@@ -32,7 +32,10 @@ spec:
         - name: TOPIC
           value: "NativeCmsMetadataPublicationEvents"
         - name: PRODUCER_HOST
-          value: "http://kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: PRODUCER_HOST_HEADER
           value: "kafka-proxy"
         - name: PRODUCER_TYPE

--- a/kube-config-files/cms-notifier.yaml
+++ b/kube-config-files/cms-notifier.yaml
@@ -24,9 +24,15 @@ spec:
         - name: JAVA_OPTS
           value: "-Xms544m -Xmx544m -XX:+UseG1GC -server"
         - name: KAFKA_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.host
         - name: KAFKA_PORT
-          value: "9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.port
         - name: KAFKA_TOPIC
           value: "NativeCmsPublicationEvents"
         - name: RESPECT_EXISTING_TIMESTAMP

--- a/kube-config-files/concept-ingester-red.yaml
+++ b/kube-config-files/concept-ingester-red.yaml
@@ -27,7 +27,10 @@ spec:
         - name: PORT
           value: "8080"
         - name: KAFKA_PROXY_ADDRESS
-          value: "http://kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
         - name: GROUP_ID
           value: "RedConcepts"
         - name: TOPIC

--- a/kube-config-files/concept-ingester-red.yaml
+++ b/kube-config-files/concept-ingester-red.yaml
@@ -39,7 +39,10 @@ spec:
         - name: QUEUE_ID
           value: "kafka"
         - name: GRAPHITE_TCP_AUTHORITY
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.concept-ingester-red"
         - name: OFFSET

--- a/kube-config-files/concept-suggestion-api.yaml
+++ b/kube-config-files/concept-suggestion-api.yaml
@@ -34,7 +34,10 @@ spec:
         - name: CES_PING
           value: "/worker/admin/ping"
         - name: KAFKA_ADDRESS
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: GRAPHITE_HOST
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/concept-suggestion-api.yaml
+++ b/kube-config-files/concept-suggestion-api.yaml
@@ -36,9 +36,15 @@ spec:
         - name: KAFKA_ADDRESS
           value: "kafka:8082"
         - name: GRAPHITE_HOST
-          value: "graphite.ft.com"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.host
         - name: GRAPHITE_PORT
-          value: "2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.port
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.concept-suggestion-api"
         - name: WHITELIST

--- a/kube-config-files/concepts-kafka-bridge-pub-pre-prod.yaml
+++ b/kube-config-files/concepts-kafka-bridge-pub-pre-prod.yaml
@@ -33,7 +33,10 @@ spec:
         - name: TOPIC
           value: "Concept"
         - name: PRODUCER_HOST
-          value: "http://kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: PRODUCER_TYPE
           value: "proxy"
         - name: AUTHORIZATION_KEY

--- a/kube-config-files/content-ingester-neo4j-red.yaml
+++ b/kube-config-files/content-ingester-neo4j-red.yaml
@@ -58,7 +58,10 @@ spec:
         - name: FORWARD_TO_TOPIC_NAME
           value: "PostPublicationEvents"
         - name: KAFKA_PROXY_URL
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: WRITER_URL
           value: "content-rw-neo4j-red:8080"
         - name: ZOOKEEPER_HOST

--- a/kube-config-files/content-ingester-neo4j-red.yaml
+++ b/kube-config-files/content-ingester-neo4j-red.yaml
@@ -30,9 +30,15 @@ spec:
         - name: ADMIN_PORT
           value: "8081"
         - name: KAFKA_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.host
         - name: KAFKA_PORT
-          value: "9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.port
         - name: KAFKA_GROUPNAME
           value: "content-neo4j-red"
         - name: KAFKA_SYSTEM_ID

--- a/kube-config-files/content-ingester-neo4j-red.yaml
+++ b/kube-config-files/content-ingester-neo4j-red.yaml
@@ -65,9 +65,15 @@ spec:
         - name: WRITER_URL
           value: "content-rw-neo4j-red:8080"
         - name: ZOOKEEPER_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.host
         - name: ZOOKEEPER_PORT
-          value: "2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.port
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/content-ingester.yaml
+++ b/kube-config-files/content-ingester.yaml
@@ -65,9 +65,15 @@ spec:
         - name: WRITER_URL
           value: "document-store-api:8080"
         - name: ZOOKEEPER_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.host
         - name: ZOOKEEPER_PORT
-          value: "2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.port
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/content-ingester.yaml
+++ b/kube-config-files/content-ingester.yaml
@@ -58,7 +58,10 @@ spec:
         - name: FORWARD_TO_TOPIC_NAME
           value: "PostPublicationEvents"
         - name: KAFKA_PROXY_URL
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: WRITER_URL
           value: "document-store-api:8080"
         - name: ZOOKEEPER_HOST

--- a/kube-config-files/content-ingester.yaml
+++ b/kube-config-files/content-ingester.yaml
@@ -30,9 +30,15 @@ spec:
         - name: ADMIN_PORT
           value: "8081"
         - name: KAFKA_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.host
         - name: KAFKA_PORT
-          value: "9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.port
         - name: KAFKA_GROUPNAME
           value: "content"
         - name: KAFKA_SYSTEM_ID

--- a/kube-config-files/content-preview.yaml
+++ b/kube-config-files/content-preview.yaml
@@ -34,7 +34,10 @@ spec:
         - name: TRANSFORM_APP_PANIC_GUIDE
           value: https://dewey.ft.com/up-mlm.html
         - name: GRAPHITE_TCP_ADDRESS
-          value: graphite.ft.com:2003
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: coco.services.k8s.content-preview
         - name: SOURCE_APP_NAME

--- a/kube-config-files/content-rw-neo4j-red.yaml
+++ b/kube-config-files/content-rw-neo4j-red.yaml
@@ -28,7 +28,10 @@ spec:
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: GRAPHITE_ADDRESS
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/content-rw-neo4j-red.yaml
+++ b/kube-config-files/content-rw-neo4j-red.yaml
@@ -26,7 +26,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         - name: BATCH_SIZE
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/content-rw-neo4j-red.yaml
+++ b/kube-config-files/content-rw-neo4j-red.yaml
@@ -30,7 +30,10 @@ spec:
         - name: BATCH_SIZE
           value: "50"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.content-rw-neo4j-red"
         ports:

--- a/kube-config-files/diamond.yaml
+++ b/kube-config-files/diamond.yaml
@@ -26,9 +26,15 @@ spec:
           mountPath: /host_proc
         env:
         - name: GRAPHITE_HOST
-          value: graphite.ft.com
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.host
         - name: GRAPHITE_PORT
-          value: "2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.port
         - name: INTERVAL
           value: "60"
         - name: PREFIX

--- a/kube-config-files/financial-instruments-rw-neo4j-red.yaml
+++ b/kube-config-files/financial-instruments-rw-neo4j-red.yaml
@@ -34,7 +34,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.financial-instruments-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/financial-instruments-rw-neo4j-red.yaml
+++ b/kube-config-files/financial-instruments-rw-neo4j-red.yaml
@@ -39,7 +39,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/financial-instruments-rw-neo4j-red.yaml
+++ b/kube-config-files/financial-instruments-rw-neo4j-red.yaml
@@ -27,7 +27,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.financial-instruments-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/genres-rw-neo4j-red.yaml
+++ b/kube-config-files/genres-rw-neo4j-red.yaml
@@ -32,7 +32,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.genres-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/genres-rw-neo4j-red.yaml
+++ b/kube-config-files/genres-rw-neo4j-red.yaml
@@ -37,7 +37,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort:  8080
         livenessProbe:

--- a/kube-config-files/genres-rw-neo4j-red.yaml
+++ b/kube-config-files/genres-rw-neo4j-red.yaml
@@ -25,7 +25,10 @@ spec:
             memory: 256Mi
         env:
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.genres-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/global-config/global-config.yaml
+++ b/kube-config-files/global-config/global-config.yaml
@@ -27,6 +27,7 @@ data:
   kafka.proxy.url : kafka:8082
   kafka.proxy.host : kafka
   kafka.proxy.port : "8082"
+  kafka.proxy.url.with.protocol: http://kafka:8082
   zookeeper.url : kafka:2181
   zookeeper.host : kafka
   zookeeper.port : "2181"

--- a/kube-config-files/global-config/global-config.yaml
+++ b/kube-config-files/global-config/global-config.yaml
@@ -20,3 +20,4 @@ data:
   graphite.host: graphite.ft.com
   graphite.port: "2003"
   neo4j.statements.batch.size: "50"
+  neo4j.url: http://neo4j-red:7474/db/data/

--- a/kube-config-files/global-config/global-config.yaml
+++ b/kube-config-files/global-config/global-config.yaml
@@ -19,3 +19,4 @@ data:
   graphite.address: "graphite.ft.com:2003"
   graphite.host: graphite.ft.com
   graphite.port: "2003"
+  neo4j.statements.batch.size: "50"

--- a/kube-config-files/global-config/global-config.yaml
+++ b/kube-config-files/global-config/global-config.yaml
@@ -21,3 +21,12 @@ data:
   graphite.port: "2003"
   neo4j.statements.batch.size: "50"
   neo4j.url: http://neo4j-red:7474/db/data/
+  kafka.url : kafka:9092
+  kafka.host : kafka
+  kafka.port : "9092"
+  kafka.proxy.url : kafka:8082
+  kafka.proxy.host : kafka
+  kafka.proxy.port : "8082"
+  zookeeper.url : kafka:2181
+  zookeeper.host : kafka
+  zookeeper.port : "2181"

--- a/kube-config-files/global-config/global-config.yaml
+++ b/kube-config-files/global-config/global-config.yaml
@@ -16,3 +16,6 @@ data:
   methode.api_uri: https://methodeapi-test.ft.com/eom-file/
   methode.health_uri: https://methodeapi-test.ft.com/build-info
   environment: "k8s-test"
+  graphite.address: "graphite.ft.com:2003"
+  graphite.host: graphite.ft.com
+  graphite.port: "2003"

--- a/kube-config-files/industry-classifications-rw-neo4j-red.yaml
+++ b/kube-config-files/industry-classifications-rw-neo4j-red.yaml
@@ -39,7 +39,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/industry-classifications-rw-neo4j-red.yaml
+++ b/kube-config-files/industry-classifications-rw-neo4j-red.yaml
@@ -34,7 +34,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.industry-classifications-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/industry-classifications-rw-neo4j-red.yaml
+++ b/kube-config-files/industry-classifications-rw-neo4j-red.yaml
@@ -27,7 +27,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.industry-classifications-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/list-notifications-ingester.yaml
+++ b/kube-config-files/list-notifications-ingester.yaml
@@ -58,7 +58,10 @@ spec:
         - name: MESSAGE_FORWARDING_ENABLED
           value: "false"
         - name: KAFKA_PROXY_URL
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: WRITER_URL
           value: "list-notifications-rw:8080"
         - name: ZOOKEEPER_HOST

--- a/kube-config-files/list-notifications-ingester.yaml
+++ b/kube-config-files/list-notifications-ingester.yaml
@@ -32,9 +32,15 @@ spec:
         - name: ADMIN_PORT
           value: "8081"
         - name: KAFKA_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.host
         - name: KAFKA_PORT
-          value: "9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.port
         - name: KAFKA_GROUPNAME
           value: "list-notifications"
         - name: KAFKA_SYSTEM_ID

--- a/kube-config-files/list-notifications-ingester.yaml
+++ b/kube-config-files/list-notifications-ingester.yaml
@@ -65,9 +65,15 @@ spec:
         - name: WRITER_URL
           value: "list-notifications-rw:8080"
         - name: ZOOKEEPER_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.host
         - name: ZOOKEEPER_PORT
-          value: "2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.port
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/list-notifications-push.yaml
+++ b/kube-config-files/list-notifications-push.yaml
@@ -22,7 +22,10 @@ spec:
         imagePullPolicy: Always
         env:
         - name: QUEUE_PROXY_ADDRS
-          value: "http://kafka:8082" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
         - name: GROUP_ID
           value: "K8S-list-notifications-push"
         - name: TOPIC

--- a/kube-config-files/locations-rw-neo4j-red.yaml
+++ b/kube-config-files/locations-rw-neo4j-red.yaml
@@ -32,7 +32,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.locations-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/locations-rw-neo4j-red.yaml
+++ b/kube-config-files/locations-rw-neo4j-red.yaml
@@ -37,7 +37,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/locations-rw-neo4j-red.yaml
+++ b/kube-config-files/locations-rw-neo4j-red.yaml
@@ -25,7 +25,10 @@ spec:
             memory: 256Mi
         env:
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.locations-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/memberships-rw-neo4j-red.yaml
+++ b/kube-config-files/memberships-rw-neo4j-red.yaml
@@ -34,7 +34,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.memberships-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/memberships-rw-neo4j-red.yaml
+++ b/kube-config-files/memberships-rw-neo4j-red.yaml
@@ -39,7 +39,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/memberships-rw-neo4j-red.yaml
+++ b/kube-config-files/memberships-rw-neo4j-red.yaml
@@ -27,7 +27,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.memberships-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/methode-article-internal-components-mapper.yaml
+++ b/kube-config-files/methode-article-internal-components-mapper.yaml
@@ -37,7 +37,10 @@ spec:
         - name: METHODE_ARTICLE_MAPPER_URL
           value: "methode-article-mapper:8080" 
         - name: KAFKA_PROXY_URL
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/methode-article-mapper.yaml
+++ b/kube-config-files/methode-article-mapper.yaml
@@ -39,7 +39,10 @@ spec:
         - name: CONCORDANCE_API_URL
           value: "public-concordances-api:8080"
         - name: KAFKA_PROXY_URL
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/methode-content-placeholder.yaml
+++ b/kube-config-files/methode-content-placeholder.yaml
@@ -35,9 +35,15 @@ spec:
           periodSeconds: 30
         env:
         - name: Q_READ_ADDR
-          value: "http://kafka:8082" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
         - name: Q_WRITE_ADDR
-          value: "http://kafka:8082" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
         - name: Q_GROUP
           value: "mcpm"
         - name: Q_READ_TOPIC

--- a/kube-config-files/methode-image-binary-mapper.yaml
+++ b/kube-config-files/methode-image-binary-mapper.yaml
@@ -23,7 +23,10 @@ spec:
         - name: JAVA_OPTS
           value: "-Xms256m -Xmx256m -XX:+UseG1GC -server"
         - name: KAFKA_PROXY
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/methode-image-model-mapper.yaml
+++ b/kube-config-files/methode-image-model-mapper.yaml
@@ -24,7 +24,10 @@ spec:
         - name: JAVA_OPTS
           value: "-Xms256m -Xmx256m -XX:+UseG1GC -server"
         - name: KAFKA_PROXY
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: S3_URL
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/methode-image-set-mapper.yaml
+++ b/kube-config-files/methode-image-set-mapper.yaml
@@ -23,7 +23,10 @@ spec:
         - name: JAVA_OPTS
           value: "-Xms256m -Xmx256m -XX:+UseG1GC -server"
         - name: KAFKA_PROXY
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/methode-list-mapper.yaml
+++ b/kube-config-files/methode-list-mapper.yaml
@@ -41,7 +41,10 @@ spec:
         - name: THINGS_API_URL
           value: "public-things-api:8080"
         - name: KAFKA_PROXY_URL
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/notifications-ingester.yaml
+++ b/kube-config-files/notifications-ingester.yaml
@@ -30,9 +30,15 @@ spec:
         - name: ADMIN_PORT
           value: "8081"
         - name: KAFKA_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.host
         - name: KAFKA_PORT
-          value: "9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.port
         - name: KAFKA_GROUPNAME
           value: "notifications"
         - name: KAFKA_SYSTEM_ID

--- a/kube-config-files/notifications-ingester.yaml
+++ b/kube-config-files/notifications-ingester.yaml
@@ -56,7 +56,10 @@ spec:
         - name: MESSAGE_FORWARDING_ENABLED
           value: "false"
         - name: KAFKA_PROXY_URL
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: WRITER_URL
           value: "notifications-rw:8080"
         - name: ZOOKEEPER_HOST

--- a/kube-config-files/notifications-ingester.yaml
+++ b/kube-config-files/notifications-ingester.yaml
@@ -63,9 +63,15 @@ spec:
         - name: WRITER_URL
           value: "notifications-rw:8080"
         - name: ZOOKEEPER_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.host
         - name: ZOOKEEPER_PORT
-          value: "2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.port
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/notifications-push.yaml
+++ b/kube-config-files/notifications-push.yaml
@@ -22,7 +22,10 @@ spec:
         imagePullPolicy: Always
         env:
         - name: QUEUE_PROXY_ADDRS
-          value: "http://kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
         - name: GROUP_ID
           value: "k8s-list-notifications-push"
         - name: TOPIC

--- a/kube-config-files/organisations-rw-neo4j-red.yaml
+++ b/kube-config-files/organisations-rw-neo4j-red.yaml
@@ -39,7 +39,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/organisations-rw-neo4j-red.yaml
+++ b/kube-config-files/organisations-rw-neo4j-red.yaml
@@ -27,7 +27,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.organisations-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/organisations-rw-neo4j-red.yaml
+++ b/kube-config-files/organisations-rw-neo4j-red.yaml
@@ -34,7 +34,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.organisations-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/people-rw-neo4j-red.yaml
+++ b/kube-config-files/people-rw-neo4j-red.yaml
@@ -27,7 +27,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.people-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/people-rw-neo4j-red.yaml
+++ b/kube-config-files/people-rw-neo4j-red.yaml
@@ -34,7 +34,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.people-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	"
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/people-rw-neo4j-red.yaml
+++ b/kube-config-files/people-rw-neo4j-red.yaml
@@ -37,9 +37,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: global-config
-              key: neo4j.statements.batch.size	"
+              key: neo4j.statements.batch.size
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/public-annotations-api.yml
+++ b/kube-config-files/public-annotations-api.yml
@@ -26,7 +26,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.public-annotations-api"
         - name: LOG_METRICS

--- a/kube-config-files/public-annotations-api.yml
+++ b/kube-config-files/public-annotations-api.yml
@@ -37,7 +37,10 @@ spec:
         - name: CACHE_DURATION
           value: "30s"
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/public-brands-api.yaml
+++ b/kube-config-files/public-brands-api.yaml
@@ -22,7 +22,10 @@ spec:
         imagePullPolicy: Always
         env:
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         - name: CACHE_DURATION
           value: 10m
         - name: GRAPHITE_ADDRESS

--- a/kube-config-files/public-brands-api.yaml
+++ b/kube-config-files/public-brands-api.yaml
@@ -26,7 +26,10 @@ spec:
         - name: CACHE_DURATION
           value: 10m
         - name: GRAPHITE_ADDRESS
-          value: graphite.ft.com:2003
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: coco.services.k8s.public-brands-api
         resources:

--- a/kube-config-files/public-concordances-api.yaml
+++ b/kube-config-files/public-concordances-api.yaml
@@ -27,7 +27,10 @@ spec:
         - name: APP_PORT
           value: "8080" 
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.public-concordances-api"
         - name: LOG_METRICS

--- a/kube-config-files/public-concordances-api.yaml
+++ b/kube-config-files/public-concordances-api.yaml
@@ -38,7 +38,10 @@ spec:
         - name: CACHE_DURATION
           value: "10m" 
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort:  8080
         livenessProbe:

--- a/kube-config-files/public-content-by-concept-api.yaml
+++ b/kube-config-files/public-content-by-concept-api.yaml
@@ -22,7 +22,10 @@ spec:
         imagePullPolicy: Always
         env:
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         - name: APP_PORT
           value: "8080"
         - name: CACHE_DURATION

--- a/kube-config-files/public-content-by-concept-api.yaml
+++ b/kube-config-files/public-content-by-concept-api.yaml
@@ -28,7 +28,10 @@ spec:
         - name: CACHE_DURATION
           value: 30s
         - name: GRAPHITE_ADDRESS
-          value: graphite.ft.com:2003
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: coco.services.k8s.public-content-by-concept-api
         resources:

--- a/kube-config-files/public-organisations-api.yaml
+++ b/kube-config-files/public-organisations-api.yaml
@@ -22,7 +22,10 @@ spec:
         imagePullPolicy: Always
         env:
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         - name: CACHE_DURATION
           value: 24h
         - name: GRAPHITE_ADDRESS

--- a/kube-config-files/public-organisations-api.yaml
+++ b/kube-config-files/public-organisations-api.yaml
@@ -26,7 +26,10 @@ spec:
         - name: CACHE_DURATION
           value: 24h
         - name: GRAPHITE_ADDRESS
-          value: graphite.ft.com:2003
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: coco.services.k8s.public-organisations-api
         resources:

--- a/kube-config-files/public-people-api.yaml
+++ b/kube-config-files/public-people-api.yaml
@@ -26,7 +26,10 @@ spec:
         - name: CACHE_DURATION
           value: 10m
         - name: GRAPHITE_ADDRESS
-          value: graphite.ft.com:2003
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: coco.services.k8s.public-people-api
         resources:

--- a/kube-config-files/public-people-api.yaml
+++ b/kube-config-files/public-people-api.yaml
@@ -22,7 +22,10 @@ spec:
         imagePullPolicy: Always
         env:
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         - name: CACHE_DURATION
           value: 10m
         - name: GRAPHITE_ADDRESS

--- a/kube-config-files/public-six-degrees-api.yaml
+++ b/kube-config-files/public-six-degrees-api.yaml
@@ -26,7 +26,10 @@ spec:
         - name: CACHE_DURATION
           value: 24h
         - name: GRAPHITE_ADDRESS
-          value: graphite.ft.com:2003
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: coco.services.k8s.public-six-degrees-api
         resources:

--- a/kube-config-files/public-six-degrees-api.yaml
+++ b/kube-config-files/public-six-degrees-api.yaml
@@ -22,7 +22,10 @@ spec:
         imagePullPolicy: Always
         env:
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         - name: CACHE_DURATION
           value: 24h
         - name: GRAPHITE_ADDRESS

--- a/kube-config-files/public-things-api.yaml
+++ b/kube-config-files/public-things-api.yaml
@@ -27,7 +27,10 @@ spec:
         - name: APP_PORT
           value: "8080" 
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.public-things-api"
         - name: LOG_METRICS

--- a/kube-config-files/public-things-api.yaml
+++ b/kube-config-files/public-things-api.yaml
@@ -38,7 +38,10 @@ spec:
         - name: CACHE_DURATION
           value: "30s" 
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort:  8080
         livenessProbe:

--- a/kube-config-files/rec-reads-content-annotator.yaml
+++ b/kube-config-files/rec-reads-content-annotator.yaml
@@ -25,7 +25,10 @@ spec:
         - name: GROUP_ID
           value: "k8s-rec-reads-content-annotator"
         - name: ZOOKEEPER_ENDPOINTS
-          value: "kafka:2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.url	
         - name: KAFKA_ENDPOINTS
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/rec-reads-content-annotator.yaml
+++ b/kube-config-files/rec-reads-content-annotator.yaml
@@ -27,7 +27,10 @@ spec:
         - name: ZOOKEEPER_ENDPOINTS
           value: "kafka:2181"
         - name: KAFKA_ENDPOINTS
-          value: "kafka:9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.url  
         - name: WRITER_ENDPOINT
           value: "v2-annotations-rw-red:8080:8080"
         - name: ANNOTATING_SYSTEM

--- a/kube-config-files/rec-reads-content-annotator.yaml
+++ b/kube-config-files/rec-reads-content-annotator.yaml
@@ -33,13 +33,19 @@ spec:
         - name: ANNOTATING_SYSTEM
           value: "concept-suggestor"
         - name: GRAPHITE_HOST
-          value: "graphite.ft.com"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.host
+        - name: GRAPHITE_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.port
         - name: JAVA_OPTS
           value: "-Xms128m -Xmx128m -XX:+UseG1GC -server"
         - name: FILTER_NOVELTIES
           value: "true"
-        - name: GRAPHITE_PORT
-          value: "2003"
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.rec-reads-content-annotator"
         ports:

--- a/kube-config-files/rec-reads-content-ingester.yaml
+++ b/kube-config-files/rec-reads-content-ingester.yaml
@@ -58,7 +58,10 @@ spec:
         - name: MESSAGE_FORWARDING_ENABLED
           value: "false"
         - name: KAFKA_PROXY_URL
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: WRITER_URL
           value: "upp-uk-gateway-test.in.ft.com:443"
         - name: WRITER_CREDENTIALS

--- a/kube-config-files/rec-reads-content-ingester.yaml
+++ b/kube-config-files/rec-reads-content-ingester.yaml
@@ -32,9 +32,15 @@ spec:
         - name: ADMIN_PORT
           value: "8081"
         - name: KAFKA_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.host
         - name: KAFKA_PORT
-          value: "9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.port
         - name: KAFKA_GROUPNAME
           value: "rec-reads-content-ingester"
         - name: KAFKA_SYSTEM_ID

--- a/kube-config-files/rec-reads-content-ingester.yaml
+++ b/kube-config-files/rec-reads-content-ingester.yaml
@@ -70,9 +70,15 @@ spec:
               name: global-secrets
               key: upp_gateway.authorization_key
         - name: ZOOKEEPER_HOST
-          value: "kafka"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.host
         - name: ZOOKEEPER_PORT
-          value: "2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.port
         ports:
         - containerPort: 8080
         - containerPort: 8081

--- a/kube-config-files/roles-rw-neo4j-red.yaml
+++ b/kube-config-files/roles-rw-neo4j-red.yaml
@@ -34,7 +34,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.roles-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/roles-rw-neo4j-red.yaml
+++ b/kube-config-files/roles-rw-neo4j-red.yaml
@@ -27,7 +27,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.roles-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/roles-rw-neo4j-red.yaml
+++ b/kube-config-files/roles-rw-neo4j-red.yaml
@@ -39,7 +39,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/sections-rw-neo4j-red.yaml
+++ b/kube-config-files/sections-rw-neo4j-red.yaml
@@ -32,7 +32,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.sections-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/sections-rw-neo4j-red.yaml
+++ b/kube-config-files/sections-rw-neo4j-red.yaml
@@ -24,8 +24,11 @@ spec:
           limits:
             memory: 256Mi
         env:
-        - name: GRAPHITE_TCP_ADDRESS
-          value: "graphite.ft.com:2003"
+        - name: GRAPHITE_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.sections-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/sections-rw-neo4j-red.yaml
+++ b/kube-config-files/sections-rw-neo4j-red.yaml
@@ -37,7 +37,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/special-reports-rw-neo4j-red.yaml
+++ b/kube-config-files/special-reports-rw-neo4j-red.yaml
@@ -24,8 +24,11 @@ spec:
           limits:
             memory: 256Mi
         env:
-        - name: GRAPHITE_TCP_ADDRESS
-          value: "graphite.ft.com:2003"
+        - name: GRAPHITE_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.special-reports-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/special-reports-rw-neo4j-red.yaml
+++ b/kube-config-files/special-reports-rw-neo4j-red.yaml
@@ -32,7 +32,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.special-reports-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/special-reports-rw-neo4j-red.yaml
+++ b/kube-config-files/special-reports-rw-neo4j-red.yaml
@@ -37,7 +37,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/subjects-rw-neo4j-red.yaml
+++ b/kube-config-files/subjects-rw-neo4j-red.yaml
@@ -24,8 +24,11 @@ spec:
           limits:
             memory: 256Mi
         env:
-        - name: GRAPHITE_TCP_ADDRESS
-          value: "graphite.ft.com:2003"
+        - name: GRAPHITE_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.subjects-rw-neo4j-red"
         - name: BATCH_SIZE

--- a/kube-config-files/subjects-rw-neo4j-red.yaml
+++ b/kube-config-files/subjects-rw-neo4j-red.yaml
@@ -37,7 +37,10 @@ spec:
               name: global-config
               key: neo4j.statements.batch.size	
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/subjects-rw-neo4j-red.yaml
+++ b/kube-config-files/subjects-rw-neo4j-red.yaml
@@ -32,7 +32,10 @@ spec:
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.subjects-rw-neo4j-red"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/" 
         ports:

--- a/kube-config-files/topics-rw-neo4j-red.yaml
+++ b/kube-config-files/topics-rw-neo4j-red.yaml
@@ -20,8 +20,11 @@ spec:
       - name: topics-rw-neo4j-red
         image: coco/topics-rw-neo4j:v1.1.3
         env:
-          - name: NEO_URL
-            value: http://neo4j-red:7474/db/data/
+        - name: NEO_URL
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/kube-config-files/v1-annotations-rw-red.yaml
+++ b/kube-config-files/v1-annotations-rw-red.yaml
@@ -39,7 +39,10 @@ spec:
         - name: NEO_URL
           value: "http://neo4j-red:7474/db/data/"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: GRAPHITE_ADDRESS
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/v1-annotations-rw-red.yaml
+++ b/kube-config-files/v1-annotations-rw-red.yaml
@@ -37,7 +37,10 @@ spec:
         - name: PLATFORM_VERSION
           value: "v1"
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data/"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         - name: BATCH_SIZE
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/v1-annotations-rw-red.yaml
+++ b/kube-config-files/v1-annotations-rw-red.yaml
@@ -49,7 +49,7 @@ spec:
               name: global-config
               key: graphite.address
         - name: GRAPHITE_PREFIX
-          value: "coco.services.k8s-test.v1-annotations-rw-neo4j-red"
+          value: "coco.services.k8s.v1-annotations-rw-neo4j-red"
         - name: LOG_METRICS
           value: "false"
         - name: APP_PORT

--- a/kube-config-files/v1-annotations-rw-red.yaml
+++ b/kube-config-files/v1-annotations-rw-red.yaml
@@ -41,7 +41,10 @@ spec:
         - name: BATCH_SIZE
           value: "50"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s-test.v1-annotations-rw-neo4j-red"
         - name: LOG_METRICS

--- a/kube-config-files/v1-content-annotator-binding-service-red.yaml
+++ b/kube-config-files/v1-content-annotator-binding-service-red.yaml
@@ -48,9 +48,15 @@ spec:
         - name: FILTER_NOVELTIES
           value: "true"
         - name: GRAPHITE_HOST
-          value: "graphite.ft.com"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.host
         - name: GRAPHITE_PORT
-          value: "2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.port
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s-test.v1-content-annotator-binding-service-red"
         ports:

--- a/kube-config-files/v1-content-annotator-binding-service-red.yaml
+++ b/kube-config-files/v1-content-annotator-binding-service-red.yaml
@@ -36,7 +36,10 @@ spec:
         - name: GROUP_ID
           value: "v1-content-annotator-binding-service-red-k8s"
         - name: ZOOKEEPER_ENDPOINTS
-          value: "kafka:2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.url	
         - name: KAFKA_ENDPOINTS
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/v1-content-annotator-binding-service-red.yaml
+++ b/kube-config-files/v1-content-annotator-binding-service-red.yaml
@@ -58,7 +58,7 @@ spec:
               name: global-config
               key: graphite.port
         - name: GRAPHITE_PREFIX
-          value: "coco.services.k8s-test.v1-content-annotator-binding-service-red"
+          value: "coco.services.k8s.v1-content-annotator-binding-service-red"
         ports:
         - containerPort: 8080
 

--- a/kube-config-files/v1-content-annotator-binding-service-red.yaml
+++ b/kube-config-files/v1-content-annotator-binding-service-red.yaml
@@ -38,7 +38,10 @@ spec:
         - name: ZOOKEEPER_ENDPOINTS
           value: "kafka:2181"
         - name: KAFKA_ENDPOINTS
-          value: "kafka:9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.url  
         - name: WRITER_ENDPOINT
           value: "v1-annotations-rw-red:8080:8080"
         - name: ANNOTATING_SYSTEM

--- a/kube-config-files/v1-content-annotator-brightcove-red.yaml
+++ b/kube-config-files/v1-content-annotator-brightcove-red.yaml
@@ -58,7 +58,7 @@ spec:
               name: global-config
               key: graphite.port
         - name: GRAPHITE_PREFIX
-          value: "coco.services.k8s-test.v1-content-annotator-brightcove-red-service"
+          value: "coco.services.k8s.v1-content-annotator-brightcove-red-service"
         ports:
         - containerPort: 8080
 

--- a/kube-config-files/v1-content-annotator-brightcove-red.yaml
+++ b/kube-config-files/v1-content-annotator-brightcove-red.yaml
@@ -48,9 +48,15 @@ spec:
         - name: FILTER_NOVELTIES
           value: "true"
         - name: GRAPHITE_HOST
-          value: "graphite.ft.com"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.host
         - name: GRAPHITE_PORT
-          value: "2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.port
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s-test.v1-content-annotator-brightcove-red-service"
         ports:

--- a/kube-config-files/v1-content-annotator-brightcove-red.yaml
+++ b/kube-config-files/v1-content-annotator-brightcove-red.yaml
@@ -36,7 +36,10 @@ spec:
         - name: GROUP_ID
           value: "v1-content-annotator-brightcove-red-service-k8s"
         - name: ZOOKEEPER_ENDPOINTS
-          value: "kafka:2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.url	
         - name: KAFKA_ENDPOINTS
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/v1-content-annotator-brightcove-red.yaml
+++ b/kube-config-files/v1-content-annotator-brightcove-red.yaml
@@ -38,7 +38,10 @@ spec:
         - name: ZOOKEEPER_ENDPOINTS
           value: "kafka:2181"
         - name: KAFKA_ENDPOINTS
-          value: "kafka:9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.url  
         - name: WRITER_ENDPOINT
           value: "brightcove-annotations-rw-red:8080:8080"
         - name: ANNOTATING_SYSTEM

--- a/kube-config-files/v1-suggestor.yaml
+++ b/kube-config-files/v1-suggestor.yaml
@@ -35,7 +35,10 @@ spec:
           periodSeconds: 30
         env:
         - name: SRC_ADDR
-          value: "http://kafka:8082" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
         - name: SRC_GROUP
           value: "v1Suggestor" 
         - name: SRC_TOPIC
@@ -43,7 +46,10 @@ spec:
         - name: SRC_CONCURRENT_PROCESSING
           value: "false" 
         - name: DEST_ADDRESS
-          value: "http://kafka:8082" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
         - name: DEST_TOPIC
           value: "ConceptSuggestions" 
         ports:

--- a/kube-config-files/v2-annotations-rw-red.yaml
+++ b/kube-config-files/v2-annotations-rw-red.yaml
@@ -32,7 +32,10 @@ spec:
         - name: APP_PORT
           value: "8080"
         - name: BATCH_SIZE
-          value: "50"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.statements.batch.size	
         - name: GRAPHITE_ADDRESS
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/v2-annotations-rw-red.yaml
+++ b/kube-config-files/v2-annotations-rw-red.yaml
@@ -28,7 +28,10 @@ spec:
         - name: ANNOTATION_LIFECYCLE
           value: "v2-annotations"
         - name: NEO_URL
-          value: "http://neo4j-red:7474/db/data"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: neo4j.url  
         - name: APP_PORT
           value: "8080"
         - name: BATCH_SIZE

--- a/kube-config-files/v2-annotations-rw-red.yaml
+++ b/kube-config-files/v2-annotations-rw-red.yaml
@@ -34,7 +34,10 @@ spec:
         - name: BATCH_SIZE
           value: "50"
         - name: GRAPHITE_ADDRESS
-          value: "graphite.ft.com:2003"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.v2-annotations-rw-red"
         - name: LOG_METRICS

--- a/kube-config-files/v2-content-annotator-red.yaml
+++ b/kube-config-files/v2-content-annotator-red.yaml
@@ -33,13 +33,19 @@ spec:
         - name: ANNOTATING_SYSTEM
           value: "concept-suggestor"
         - name: GRAPHITE_HOST
-          value: "graphite.ft.com"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.host
+        - name: GRAPHITE_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.port
         - name: JAVA_OPTS
           value: "-Xms128m -Xmx128m -XX:+UseG1GC -server"
         - name: FILTER_NOVELTIES
           value: "true"
-        - name: GRAPHITE_PORT
-          value: "2003"
         - name: GRAPHITE_PREFIX
           value: "coco.services.k8s.v2-content-annotator-red"
         - name: LOG_METRICS

--- a/kube-config-files/v2-content-annotator-red.yaml
+++ b/kube-config-files/v2-content-annotator-red.yaml
@@ -27,7 +27,10 @@ spec:
         - name: ZOOKEEPER_ENDPOINTS
           value: "kafka:2181"
         - name: KAFKA_ENDPOINTS
-          value: "kafka:9092"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.url  
         - name: WRITER_ENDPOINT
           value: "v2-annotations-rw-red:8080:8080"
         - name: ANNOTATING_SYSTEM

--- a/kube-config-files/v2-content-annotator-red.yaml
+++ b/kube-config-files/v2-content-annotator-red.yaml
@@ -25,7 +25,10 @@ spec:
         - name: GROUP_ID
           value: "k8s-v2-annotator-red"
         - name: ZOOKEEPER_ENDPOINTS
-          value: "kafka:2181"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: zookeeper.url	
         - name: KAFKA_ENDPOINTS
           valueFrom:
             configMapKeyRef:

--- a/kube-config-files/video-mapper.yaml
+++ b/kube-config-files/video-mapper.yaml
@@ -35,7 +35,10 @@ spec:
           periodSeconds: 30
         env:
         - name: Q_ADDR
-          value: "http://kafka:8082" 
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
         - name: Q_GROUP
           value: "videoMapper"
         - name: Q_READ_TOPIC

--- a/kube-config-files/wordpress-article-mapper.yaml
+++ b/kube-config-files/wordpress-article-mapper.yaml
@@ -24,7 +24,10 @@ spec:
         - name: JAVA_OPTS
           value: "-Xms384m -Xmx384m -XX:+UseG1GC -server"
         - name: KAFKA_PROXY
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         - name: READ_ENDPOINT
           value: "document-store-api:8080"
         ports:

--- a/kube-config-files/wordpress-image-mapper.yaml
+++ b/kube-config-files/wordpress-image-mapper.yaml
@@ -23,7 +23,10 @@ spec:
         - name: JAVA_OPTS
           value: "-Xms256m -Xmx256m -XX:+UseG1GC -server"
         - name: KAFKA_PROXY
-          value: "kafka:8082"
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
         ports:
         - containerPort: 8080
         - containerPort: 8081


### PR DESCRIPTION
- extracted global configs for
  - kafka
  - kafka-proxy
  - zookeeper
  - neo4j
  - graphite address
  - neo4j batch size
- changed deployments to use the global config
- made the graphite prefixes consistent