### PR TITLE
Fixed neo4j deployment, increased initial liveness probe delay 

### DIFF
--- a/kube-config-files/neo4j-red.yaml
+++ b/kube-config-files/neo4j-red.yaml
@@ -32,7 +32,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 7474
-          initialDelaySeconds: 5
+          initialDelaySeconds: 600
         volumeMounts:
          - name: neo4j-red-persistent-storage
            mountPath: /data
@@ -52,7 +52,7 @@ metadata:
     visualize: "true"
 spec:
   ports:
-      port: 7474
+    - port: 7474
       targetPort: 7474
   selector:
     app: neo4j-red


### PR DESCRIPTION
- increased liveness probe delay enables neo4j to fully intialize before being restarted
- this means that we manually have to check the health/logs in cases when we need neo4j up quickly