### PR TITLE
Update APC version and add timeout to readiness probe

### DIFF
--- a/kube-config-files/api-policy-component.yaml
+++ b/kube-config-files/api-policy-component.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: api-policy-component
-        image: coco/api-policy-component:k8s_v0.0.4
+        image: coco/api-policy-component:k8s_v0.0.9
         env:
         - name: JAVA_OPTS
           value: "-Xms384m -Xmx384m -XX:+UseG1GC -server"
@@ -51,6 +51,7 @@ spec:
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 30
+          timeoutSeconds: 5
 
 ---
 


### PR DESCRIPTION
https://github.com/Financial-Times/api-policy-component/compare/7b4258510295ce9f9f9c6d27c5cdeef2bbbe4526...1272e50081b9e17f121b39f452f604eef131c7a6