### PR TITLE
Added global services

### DIFF
--- a/pub-kube-config-files/diamond.yaml
+++ b/pub-kube-config-files/diamond.yaml
@@ -1,0 +1,57 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: diamond
+  labels:
+    app: diamond
+    visualize: "true"
+spec:
+  selector:
+    matchLabels:
+      app: diamond
+  template:
+    metadata:
+      labels:
+        app: diamond
+        visualize: "true"
+    spec:
+      containers:
+      - name: diamond
+        image: coco/coco-diamond-auto:v1.1.0
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: host-docker-sock
+          mountPath: /var/run/docker.sock
+        - name: host-docker-proc
+          mountPath: /host_proc
+        env:
+        - name: GRAPHITE_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.host
+        - name: GRAPHITE_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.port
+        - name: INTERVAL
+          value: "60"
+        - name: PREFIX
+          value: "coco.servers"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: environment
+      volumes:
+      - name: host-docker-sock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: host-docker-proc
+        hostPath:
+          path: /proc

--- a/pub-kube-config-files/elb-registrator-job.yaml
+++ b/pub-kube-config-files/elb-registrator-job.yaml
@@ -1,0 +1,69 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: elb-registrator-config
+  namespace: default
+data:
+  #TODO parameterize this to be the cluster name
+  dns.register_subdomain: k8s-publishing-upp-uk
+  k8s.entry_point_service: pub-varnish
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elb-registrator-job
+spec:
+  template:
+    metadata:
+      name: elb-registrator
+    spec:
+      # Keep trying to register in DNS until we manage to do it
+      restartPolicy: OnFailure
+      containers:
+      - name: elb-registrator
+        image: coco/coco-elb-dns-registrator:k8s_v0.0.4
+        volumeMounts:
+        #We need the certificates for being able to make the DynDNS http call
+        - mountPath: /etc/ssl/certs
+          name: certificates-storage
+        env:
+        - name: DOMAINS
+          valueFrom:
+            configMapKeyRef:
+              name: elb-registrator-config
+              key: dns.register_subdomain
+        - name: AWS_REGION
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: aws.region
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: global-secrets
+              key: aws.access_key_id
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: global-secrets
+              key: aws.secret_access_key
+        - name: KONSTRUCTOR_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: global-secrets
+              key: kon.dns_api.key
+        - name: K8S_LB_SERVICE
+          valueFrom:
+            configMapKeyRef:
+              name: elb-registrator-config
+              key: k8s.entry_point_service
+        - name: K8S_LB_SERVICE_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: k8s.app_namespace
+      volumes:
+      - name: certificates-storage
+        hostPath:
+          path: /usr/share/ca-certificates

--- a/pub-kube-config-files/global-config/global-config.yaml
+++ b/pub-kube-config-files/global-config/global-config.yaml
@@ -15,7 +15,7 @@ data:
   cache-max-age: "10"
   methode.api_uri: https://methodeapi-test.ft.com/eom-file/
   methode.health_uri: https://methodeapi-test.ft.com/build-info
-  environment: "k8s-test"
+  environment: "k8s-publishing-upp-uk"
   graphite.address: "graphite.ft.com:2003"
   graphite.host: graphite.ft.com
   graphite.port: "2003"

--- a/pub-kube-config-files/image-cleaner.yaml
+++ b/pub-kube-config-files/image-cleaner.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: image-cleaner
+  labels:
+    app: image-cleaner
+spec:
+  selector:
+    matchLabels:
+      app: image-cleaner
+  template:
+    metadata:
+      labels:
+        app: image-cleaner
+        visualize: "true"
+    spec:
+      containers:
+      - name: image-cleaner
+        image: coco/docker-gc:add-loop
+        volumeMounts:
+        - name: host-docker-sock
+          mountPath: /var/run/docker.sock
+        resources:
+          limits:
+            memory: 256Mi
+        env:
+          - name: TIME_BETWEEN_RUNS
+            value: "1d"
+        ports:
+        - containerPort: 8080
+      volumes:
+      - name: host-docker-sock
+        hostPath: 
+          path: /var/run/docker.sock

--- a/pub-kube-config-files/system-healthcheck.yaml
+++ b/pub-kube-config-files/system-healthcheck.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: system-healthcheck
+  labels:
+    app: system-healthcheck
+spec:
+  selector:
+    matchLabels:
+      app: system-healthcheck
+  template:
+    metadata:
+      labels:
+        app: system-healthcheck
+        visualize: "true"
+    spec:
+      containers:
+      - name: system-healthcheck
+        image: coco/coco-system-healthcheck:add-gtg
+        imagePullPolicy: Always
+        volumeMounts:
+        - mountPath: /host_dir
+          name: host-root-directory
+        resources:
+            limits:
+              memory: 256Mi
+        env:
+        - name: SYS_HC_HOST_PATH
+          value: "host_dir"
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          initialDelaySeconds: 5
+          tcpSocket:
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /__gtg
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+      volumes:
+      - name: host-root-directory
+        hostPath:
+          path: /
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: system-healthcheck
+  labels:
+    app: system-healthcheck
+    visualize: "true"
+    hasHealthcheck: "true"
+    isResilient: "false"
+    isDaemon: "true"
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: system-healthcheck


### PR DESCRIPTION
- diamond, image-cleaner and sys-hc are copied from the delivery cluster
- for the elb-registrator, we have to somehow parameterize the env name and the entry point, that's a TODO 