### PR TITLE
Add pub mongo

### DIFF
--- a/pub-kube-config-files/mongo-statefulset.yaml
+++ b/pub-kube-config-files/mongo-statefulset.yaml
@@ -17,9 +17,9 @@ spec:
   - ReadWriteOnce
   awsElasticBlockStore:
     fsType: ext4
-    volumeID: aws://eu-west-1a/vol-0e908cef9b28f47cd
+    volumeID: aws://eu-west-1a/vol-07588a32680f04754
   capacity:
-    storage: 10Gi
+    storage: 50Gi
   claimRef:
     apiVersion: v1
     kind: PersistentVolumeClaim
@@ -36,7 +36,7 @@ metadata:
     pv.kubernetes.io/provisioned-by: kubernetes.io/aws-ebs
   labels:
     failure-domain.beta.kubernetes.io/region: eu-west-1
-    failure-domain.beta.kubernetes.io/zone: eu-west-1a
+    failure-domain.beta.kubernetes.io/zone: eu-west-1b
   name: mongodb-1-vol
   namespace: ""
 spec:
@@ -44,9 +44,9 @@ spec:
   - ReadWriteOnce
   awsElasticBlockStore:
     fsType: ext4
-    volumeID: aws://eu-west-1a/vol-02ac9d6fcca597822
+    volumeID: aws://eu-west-1b/vol-01bdcc6868572a9f0
   capacity:
-    storage: 10Gi
+    storage: 50Gi
   claimRef:
     apiVersion: v1
     kind: PersistentVolumeClaim
@@ -63,7 +63,7 @@ metadata:
     pv.kubernetes.io/provisioned-by: kubernetes.io/aws-ebs
   labels:
     failure-domain.beta.kubernetes.io/region: eu-west-1
-    failure-domain.beta.kubernetes.io/zone: eu-west-1a
+    failure-domain.beta.kubernetes.io/zone: eu-west-1c
   name: mongodb-2-vol
   namespace: ""
 spec:
@@ -71,9 +71,9 @@ spec:
   - ReadWriteOnce
   awsElasticBlockStore:
     fsType: ext4
-    volumeID: aws://eu-west-1a/vol-072494b716f5b2fc5
+    volumeID: aws://eu-west-1c/vol-09a468d6ddf26cc9c
   capacity:
-    storage: 10Gi
+    storage: 50Gi
   claimRef:
     apiVersion: v1
     kind: PersistentVolumeClaim
@@ -134,13 +134,3 @@ spec:
         volumeMounts:
         - name: mongo-persistent
           mountPath: /data/db
-  volumeClaimTemplates:
-  - metadata:
-      name: mongo-persistent
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: gp2
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 10Gi

--- a/pub-kube-config-files/mongo-statefulset.yaml
+++ b/pub-kube-config-files/mongo-statefulset.yaml
@@ -1,0 +1,146 @@
+#The volumes used by the stateful set
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    kubernetes.io/createdby: aws-ebs-dynamic-provisioner
+    pv.kubernetes.io/bound-by-controller: "yes"
+    pv.kubernetes.io/provisioned-by: kubernetes.io/aws-ebs
+  labels:
+    failure-domain.beta.kubernetes.io/region: eu-west-1
+    failure-domain.beta.kubernetes.io/zone: eu-west-1a
+  name: mongodb-0-vol
+  namespace: "default"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  awsElasticBlockStore:
+    fsType: ext4
+    volumeID: aws://eu-west-1a/vol-0e908cef9b28f47cd
+  capacity:
+    storage: 10Gi
+  claimRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: mongo-persistent-mongodb-0
+    namespace: default
+  persistentVolumeReclaimPolicy: Retain
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    kubernetes.kuio/createdby: aws-ebs-dynamic-provisioner
+    pv.kubernetes.io/bound-by-controller: "yes"
+    pv.kubernetes.io/provisioned-by: kubernetes.io/aws-ebs
+  labels:
+    failure-domain.beta.kubernetes.io/region: eu-west-1
+    failure-domain.beta.kubernetes.io/zone: eu-west-1a
+  name: mongodb-1-vol
+  namespace: ""
+spec:
+  accessModes:
+  - ReadWriteOnce
+  awsElasticBlockStore:
+    fsType: ext4
+    volumeID: aws://eu-west-1a/vol-02ac9d6fcca597822
+  capacity:
+    storage: 10Gi
+  claimRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: mongo-persistent-mongodb-1
+    namespace: default
+  persistentVolumeReclaimPolicy: Retain
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    kubernetes.io/createdby: aws-ebs-dynamic-provisioner
+    pv.kubernetes.io/bound-by-controller: "yes"
+    pv.kubernetes.io/provisioned-by: kubernetes.io/aws-ebs
+  labels:
+    failure-domain.beta.kubernetes.io/region: eu-west-1
+    failure-domain.beta.kubernetes.io/zone: eu-west-1a
+  name: mongodb-2-vol
+  namespace: ""
+spec:
+  accessModes:
+  - ReadWriteOnce
+  awsElasticBlockStore:
+    fsType: ext4
+    volumeID: aws://eu-west-1a/vol-072494b716f5b2fc5
+  capacity:
+    storage: 10Gi
+  claimRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: mongo-persistent-mongodb-2
+    namespace: default
+  persistentVolumeReclaimPolicy: Retain
+---
+# A headless service to create DNS records
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+    visualize: "true"
+spec:
+  ports:
+  - name: work
+    port: 27017
+    targetPort: 27017
+  - name: admin
+    port: 28017
+    targetPort: 28017
+  clusterIP: None
+  selector:
+    app: mongodb
+
+# The mongo StatefulSet definition
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: mongodb
+spec:
+  serviceName: "mongodb"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: mongodb
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: mongodb
+        image: coco/coco-mongodb:v3.0.2
+        resources:
+          limits:
+            memory: 4000Mi
+        ports:
+        - containerPort: 27017
+        - containerPort: 28017
+        livenessProbe:
+          tcpSocket:
+            port: 27017
+          initialDelaySeconds: 5
+        volumeMounts:
+        - name: mongo-persistent
+          mountPath: /data/db
+  volumeClaimTemplates:
+  - metadata:
+      name: mongo-persistent
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: gp2
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
- created 3x50GiB EBS volumes, one in each availability zone in eu-west-1
- removed the `volumeClaimTemplates:` section
- didn't bring over the `storage-class.yaml`
- the changes are because we create out own volumes instead of letting it create them automatically
- will be tested in the pub cluster