### PR TITLE
Added agg-hc, configured categories based on pub-prod

### DIFF
--- a/pub-kube-config-files/upp-aggregate-healthcheck.yaml
+++ b/pub-kube-config-files/upp-aggregate-healthcheck.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: aggregate-healthcheck
-        image: coco/upp-aggregate-healthcheck:v1.0.0-rc31
+        image: coco/upp-aggregate-healthcheck:v1.1.1-rc4
         imagePullPolicy: Always
         resources:
           limits:

--- a/pub-kube-config-files/upp-aggregate-healthcheck.yaml
+++ b/pub-kube-config-files/upp-aggregate-healthcheck.yaml
@@ -27,6 +27,8 @@ spec:
         env:
         - name: PATH_PREFIX
           value: "/__health"
+        - name: ENVIRONMENT
+          value: "k8s-publishing-upp-uk"
         - name: GRAPHITE_URL
           valueFrom:
             configMapKeyRef:

--- a/pub-kube-config-files/upp-aggregate-healthcheck.yaml
+++ b/pub-kube-config-files/upp-aggregate-healthcheck.yaml
@@ -27,6 +27,11 @@ spec:
         env:
         - name: PATH_PREFIX
           value: "/__health"
+        - name: GRAPHITE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: graphite.address
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/pub-kube-config-files/upp-aggregate-healthcheck.yaml
+++ b/pub-kube-config-files/upp-aggregate-healthcheck.yaml
@@ -1,0 +1,126 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: upp-aggregate-healthcheck
+  labels:
+    app: upp-aggregate-healthcheck
+    visualize: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: upp-aggregate-healthcheck
+  template:
+    metadata:
+      labels:
+        app: upp-aggregate-healthcheck
+        version: "latest"
+        visualize: "true"
+    spec:
+      containers:
+      - name: aggregate-healthcheck
+        image: coco/upp-aggregate-healthcheck:v1.0.0-rc31
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 256Mi
+        env:
+        - name: PATH_PREFIX
+          value: "/__health"
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 30
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: upp-aggregate-healthcheck
+  labels:
+    app: upp-aggregate-healthcheck
+    visualize: "true"
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: upp-aggregate-healthcheck
+
+---
+
+kind: ConfigMapList
+apiVersion: v1
+items:
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: category.default
+      labels: 
+         healthcheck-categories-for: aggregate-healthcheck
+    data:
+      category.name: default
+      category.refreshrate: "5"
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: category.publish
+      labels: 
+        healthcheck-categories-for: aggregate-healthcheck
+    data:
+      category.name: publish
+      category.services: cms-notifier, native-ingester-cms, nativerw, wordpress-notifier
+      category.refreshrate: "60"
+      category.issticky: "true"
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: category.publishing-monitors
+      labels: 
+         healthcheck-categories-for: aggregate-healthcheck
+    data:
+      category.name: publishing-monitors
+      category.services: 
+      category.refreshrate: "60"
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: category.read
+      labels: 
+         healthcheck-categories-for: aggregate-healthcheck
+    data:
+      category.name: read
+      category.services: publish-availability-monitor, synthetic-article-publication-monitor, synthetic-list-publication-monitor
+      category.refreshrate: "4"
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: category.system
+      labels: 
+         healthcheck-categories-for: aggregate-healthcheck
+    data:
+      category.name: system
+      category.services: coreos-version-checker, system-healthcheck
+      category.refreshrate: "60"
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: category.essential-publish
+      labels: 
+         healthcheck-categories-for: aggregate-healthcheck
+    data:
+      category.name: essential-publish
+      category.services: cms-notifier, native-ingester-cms, nativerw, wordpress-notifier
+      category.refreshrate: "60"
+      category.issticky: "true"
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: healthcheck.ack.messages
+  labels: 
+    healthcheck-acknowledgements-for: aggregate-healthcheck
+data:


### PR DESCRIPTION
- the categories part has 2 identical categories (publish and essential-publish), and is outdated (doesn't have the bc notifiers, metadata stuff etc.) - we need to take another look at this sometime