### PR TITLE
Add pub content notifiers

### DIFF
--- a/pub-kube-config-files/cms-notifier.yaml
+++ b/pub-kube-config-files/cms-notifier.yaml
@@ -6,7 +6,7 @@ metadata:
     app: cms-notifier
     visualize: "true"
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: cms-notifier

--- a/pub-kube-config-files/cms-notifier.yaml
+++ b/pub-kube-config-files/cms-notifier.yaml
@@ -1,0 +1,73 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cms-notifier
+  labels:
+    app: cms-notifier
+    visualize: "true"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cms-notifier
+  template:
+    metadata:
+      labels:
+        app: cms-notifier
+        visualize: "true"
+    spec:
+      containers:
+      - name: cms-notifier
+        image: up-registry.ft.com/coco/cms-notifier:v44
+        imagePullPolicy: Always
+        env:
+        - name: JAVA_OPTS
+          value: "-Xms544m -Xmx544m -XX:+UseG1GC -server"
+        - name: KAFKA_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.host
+        - name: KAFKA_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.port
+        - name: KAFKA_TOPIC
+          value: "PreNativeCmsPublicationEvents"
+        - name: RESPECT_EXISTING_TIMESTAMP
+          value: "false"
+        ports:
+        - containerPort: 8080
+        - containerPort: 8081
+        livenessProbe:
+          initialDelaySeconds: 5
+          tcpSocket:
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /__gtg
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: cms-notifier
+  labels:
+    app: cms-notifier
+    visualize: "true"
+    hasHealthcheck: "true"
+spec:
+  ports:
+    - port: 8080
+      name: "app"
+      targetPort: 8080
+    - port: 8081
+      name: "admin"
+      targetPort: 8081
+  selector:
+    app: cms-notifier

--- a/pub-kube-config-files/secrets-templates/global-secrets-template.yaml
+++ b/pub-kube-config-files/secrets-templates/global-secrets-template.yaml
@@ -10,3 +10,4 @@ data:
   kon.dns_api.key: {{kon.dns_api.key}}
   ces.authorization_key: {{ces.authorization_key}}
   upp_gateway.authorization_key: {{upp_gateway.authorization_key}}
+  wordpress.content.api.key: {{wordpress.content.api.key}}

--- a/pub-kube-config-files/wordpress-notifier.yaml
+++ b/pub-kube-config-files/wordpress-notifier.yaml
@@ -1,0 +1,66 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: wordpress-notifier
+  labels:
+    app: wordpress-notifier
+    visualize: "true"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: wordpress-notifier
+  template:
+    metadata:
+      labels:
+        app: wordpress-notifier
+        visualize: "true"
+    spec:
+      containers:
+      - name: wordpress-notifier
+        image: up-registry.ft.com/coco/k8s-wordpress-notifier:v2
+        imagePullPolicy: Always
+        env:
+        - name: JAVA_OPTS
+          value: "-Xms544m -Xmx544m -XX:+UseG1GC -server"
+        - name: WORDPRESS_CONTENTAPI_KEY
+          valueFrom:
+            secretKeyRef:
+              name: global-secrets
+              key: wordpress.content.api.key
+        - name: CMS_NOTIFIER_URL
+          value: cms-notifier:8080
+        ports:
+        - containerPort: 8080
+        - containerPort: 8081
+        livenessProbe:
+          initialDelaySeconds: 5
+          tcpSocket:
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /__gtg
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: wordpress-notifier
+  labels:
+    app: wordpress-notifier
+    visualize: "true"
+    hasHealthcheck: "true"
+spec:
+  ports:
+    - port: 8080
+      name: "app"
+      targetPort: 8080
+    - port: 8081
+      name: "admin"
+      targetPort: 8081
+  selector:
+    app: wordpress-notifier


### PR DESCRIPTION
- wpn gtg http://git.svc.ft.com/projects/CP/repos/wordpress-notifier/pull-requests/27/overview
- wpn routing http://git.svc.ft.com/projects/CP/repos/wordpress-notifier/pull-requests/26/overview
- wpn deployed to current k8s delivery
- cms-notifier copied from delivery

