### PR TITLE
Added stable version for agg-hc and updated routing in delivery-varnish agg-hc gtg endpoint

### DIFF
--- a/delivery-kube-config-files/delivery-varnish.yaml
+++ b/delivery-kube-config-files/delivery-varnish.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: delivery-varnish
-        image: coco/delivery-varnish:k8s_v0.0.3
+        image: coco/delivery-varnish:k8s_v0.0.4
         imagePullPolicy: Always
         env:
         - name: VARNISH_BACKEND_HOST

--- a/delivery-kube-config-files/upp-aggregate-healthcheck.yaml
+++ b/delivery-kube-config-files/upp-aggregate-healthcheck.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: aggregate-healthcheck
-        image: coco/upp-aggregate-healthcheck:1.1.1
+        image: coco/upp-aggregate-healthcheck:1.1.2
         imagePullPolicy: Always
         resources:
           limits:

--- a/pub-kube-config-files/upp-aggregate-healthcheck.yaml
+++ b/pub-kube-config-files/upp-aggregate-healthcheck.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: aggregate-healthcheck
-        image: coco/upp-aggregate-healthcheck:1.1.1
+        image: coco/upp-aggregate-healthcheck:1.1.2
         imagePullPolicy: Always
         resources:
           limits:


### PR DESCRIPTION
Changes in this PR:
 - upp-agg-hc: https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/8
 - delivery varnish: https://github.com/Financial-Times/delivery-varnish/pull/10 (updated routing for agg-hc __gtg endpoint)
 
Note that auth-varnish from publishing cluster is already updated.