### PR TITLE
Reconfigured bridges

### DIFF
--- a/delivery-kube-config-files/cms-kafka-bridge-pub-k8s.yaml
+++ b/delivery-kube-config-files/cms-kafka-bridge-pub-k8s.yaml
@@ -1,0 +1,81 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cms-kafka-bridge-pub-k8s
+  labels:
+    app: cms-kafka-bridge-pub-k8s
+    visualize: "true"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cms-kafka-bridge-pub-k8s
+  template:
+    metadata:
+      labels:
+        app: cms-kafka-bridge-pub-k8s
+        visualize: "true"
+    spec:
+      containers:
+      - name: cms-kafka-bridge-k8s
+        image:  coco/coco-kafka-bridge:14.2.0-k8s-removed-host-based-routing-rc.2
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: certificates-storage
+        env:
+        - name: QUEUE_PROXY_ADDRS
+          value: "https://k8s-publishing-upp-eu.ft.com/__kafka-rest-proxy"
+        - name: GROUP_ID
+          value: "kafka-bridge-pub-k8s"
+        - name: CONSUMER_AUTOCOMMIT_ENABLE
+          value: "false"
+        - name: TOPIC
+          value: "NativeCmsPublicationEvents"
+        - name: PRODUCER_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
+        - name: PRODUCER_HOST_HEADER
+          value: "kafka-proxy"
+        - name: PRODUCER_TYPE
+          value: "proxy"
+        - name: AUTHORIZATION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: pub-auth
+              key: pub-k8s-auth
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          initialDelaySeconds: 5
+          tcpSocket:
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /__gtg
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+      volumes:
+      - name: certificates-storage
+        hostPath:
+          path: /usr/share/ca-certificates
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: cms-kafka-bridge-pub-k8s
+  labels:
+    app: cms-kafka-bridge-pub-k8s
+    visualize: "true"
+    hasHealthcheck: "true"
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: cms-kafka-bridge-pub-k8s
+

--- a/delivery-kube-config-files/cms-metadata-kafka-bridge-pub-k8s.yaml
+++ b/delivery-kube-config-files/cms-metadata-kafka-bridge-pub-k8s.yaml
@@ -1,0 +1,81 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cms-metadata-kafka-bridge-pub-k8s
+  labels:
+    app: cms-metadata-kafka-bridge-pub-k8s
+    visualize: "true"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cms-metadata-kafka-bridge-pub-k8s
+  template:
+    metadata:
+      labels:
+        app: cms-metadata-kafka-bridge-pub-k8s
+        visualize: "true"
+    spec:
+      containers:
+      - name: cms-metadata-kafka-bridge-k8s
+        image:  coco/coco-kafka-bridge:14.2.0-k8s-removed-host-based-routing-rc.2
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: certificates-storage
+        env:
+        - name: QUEUE_PROXY_ADDRS
+          value: "https://k8s-publishing-upp-eu.ft.com/__kafka-rest-proxy"
+        - name: GROUP_ID
+          value: "metadata-kafka-bridge-pub-k8s"
+        - name: CONSUMER_AUTOCOMMIT_ENABLE
+          value: "true"
+        - name: TOPIC
+          value: "NativeCmsMetadataPublicationEvents"
+        - name: PRODUCER_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
+        - name: PRODUCER_HOST_HEADER
+          value: "kafka-proxy"
+        - name: PRODUCER_TYPE
+          value: "proxy"
+        - name: AUTHORIZATION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: pub-auth
+              key: pub-k8s-auth
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          initialDelaySeconds: 5
+          tcpSocket:
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /__gtg
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+      volumes:
+      - name: certificates-storage
+        hostPath:
+          path: /usr/share/ca-certificates
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: cms-metadata-kafka-bridge-pub-k8s
+  labels:
+    app: cms-metadata-kafka-bridge-pub-k8s
+    visualize: "true"
+    hasHealthcheck: "true"
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: cms-metadata-kafka-bridge-pub-k8s
+

--- a/delivery-kube-config-files/concepts-kafka-bridge-pub-k8s.yaml
+++ b/delivery-kube-config-files/concepts-kafka-bridge-pub-k8s.yaml
@@ -1,33 +1,33 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: concepts-kafka-bridge-pub-pre-prod
+  name: concepts-kafka-bridge-pub-k8s
   labels:
-    app: concepts-kafka-bridge-pub-pre-prod
+    app: concepts-kafka-bridge-pub-k8s
     visualize: "true"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: concepts-kafka-bridge-pub-pre-prod
+      app: concepts-kafka-bridge-pub-k8s
   template:
     metadata:
       labels:
-        app: concepts-kafka-bridge-pub-pre-prod
+        app: concepts-kafka-bridge-pub-k8s
         visualize: "true"
     spec:
       containers:
-      - name: concepts-kafka-bridge-pub-pre-prod
-        image:  coco/coco-kafka-bridge:remove-host-based-routing-rc2
+      - name: concepts-kafka-bridge-k8s
+        image:  coco/coco-kafka-bridge:14.2.0-k8s-removed-host-based-routing-rc.2
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: certificates-storage
         env:
         - name: QUEUE_PROXY_ADDRS
-          value: "https://pub-pre-prod-up.ft.com/__kafka-rest-proxy"
+          value: "https://k8s-publishing-upp-eu.ft.com/__kafka-rest-proxy"
         - name: GROUP_ID
-          value: "k8s-concepts-kafka-bridge-pub-pre-prod-infraprod"
+          value: "concepts-kafka-bridge-pub-k8s"
         - name: CONSUMER_AUTOCOMMIT_ENABLE
           value: "true"
         - name: TOPIC
@@ -43,7 +43,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: pub-auth
-              key: pub-pre-prod-auth
+              key: pub-k8s-auth
         ports:
         - containerPort: 8080
         livenessProbe:
@@ -66,9 +66,9 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: concepts-kafka-bridge-pub-pre-prod
+  name: concepts-kafka-bridge-pub-k8s
   labels:
-    app: concepts-kafka-bridge-pub-pre-prod
+    app: concepts-kafka-bridge-pub-k8s
     visualize: "true"
     hasHealthcheck: "true"
 spec:
@@ -76,5 +76,5 @@ spec:
     - port: 8080
       targetPort: 8080
   selector:
-    app: concepts-kafka-bridge-pub-pre-prod
+    app: concepts-kafka-bridge-pub-k8s
 

--- a/delivery-kube-config-files/secrets-templates/pub-auth-template.yaml
+++ b/delivery-kube-config-files/secrets-templates/pub-auth-template.yaml
@@ -5,3 +5,4 @@ metadata:
 type: Opaque
 data:
   pub-pre-prod-auth: {{pub-pre-prod-auth}}
+  pub-k8s-auth: {{pub-k8s-auth}}

--- a/pub-kube-config-files/cms-kafka-bridge-pub-pre-prod.yaml
+++ b/pub-kube-config-files/cms-kafka-bridge-pub-pre-prod.yaml
@@ -1,0 +1,81 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cms-kafka-bridge-pub-pre-prod
+  labels:
+    app: cms-kafka-bridge-pub-pre-prod
+    visualize: "true"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cms-kafka-bridge-pub-pre-prod
+  template:
+    metadata:
+      labels:
+        app: cms-kafka-bridge-pub-pre-prod
+        visualize: "true"
+    spec:
+      containers:
+      - name: cms-kafka-bridge-pre-prod
+        image:  coco/coco-kafka-bridge:14.2.0-k8s-removed-host-based-routing-rc.2
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: certificates-storage
+        env:
+        - name: QUEUE_PROXY_ADDRS
+          value: "https://pub-pre-prod-uk-up.ft.com/__kafka-rest-proxy"
+        - name: GROUP_ID
+          value: "k8s-kafka-bridge-pub-pre-prod-infraprod"
+        - name: CONSUMER_AUTOCOMMIT_ENABLE
+          value: "false"
+        - name: TOPIC
+          value: "PreNativeCmsPublicationEvents"
+        - name: PRODUCER_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url.with.protocol
+        - name: PRODUCER_HOST_HEADER
+          value: "kafka-proxy"
+        - name: PRODUCER_TYPE
+          value: "proxy"
+        - name: AUTHORIZATION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: pub-auth
+              key: pub-pre-prod-auth
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          initialDelaySeconds: 5
+          tcpSocket:
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /__gtg
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+      volumes:
+      - name: certificates-storage
+        hostPath:
+          path: /usr/share/ca-certificates
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: cms-kafka-bridge-pub-pre-prod
+  labels:
+    app: cms-kafka-bridge-pub-pre-prod
+    visualize: "true"
+    hasHealthcheck: "true"
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: cms-kafka-bridge-pub-pre-prod
+

--- a/pub-kube-config-files/cms-metadata-kafka-bridge-pub-pre-prod.yaml
+++ b/pub-kube-config-files/cms-metadata-kafka-bridge-pub-pre-prod.yaml
@@ -1,24 +1,24 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: cms-kafka-bridge-pub-pre-prod
+  name: cms-metadata-kafka-bridge-pub-pre-prod
   labels:
-    app: cms-kafka-bridge-pub-pre-prod
+    app: cms-metadata-kafka-bridge-pub-pre-prod
     visualize: "true"
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: cms-kafka-bridge-pub-pre-prod
+      app: cms-metadata-kafka-bridge-pub-pre-prod
   template:
     metadata:
       labels:
-        app: cms-kafka-bridge-pub-pre-prod
+        app: cms-metadata-kafka-bridge-pub-pre-prod
         visualize: "true"
     spec:
       containers:
-      - name: cms-kafka-bridge-pre-prod
-        image:  coco/coco-kafka-bridge:remove-host-based-routing-rc2
+      - name: cms-metadata-kafka-bridge-pre-prod
+        image:  coco/coco-kafka-bridge:14.2.0-k8s-removed-host-based-routing-rc.2
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: certificates-storage
@@ -26,11 +26,11 @@ spec:
         - name: QUEUE_PROXY_ADDRS
           value: "https://pub-pre-prod-uk-up.ft.com/__kafka-rest-proxy"
         - name: GROUP_ID
-          value: "k8s-kafka-bridge-pub-pre-prod-infraprod"
+          value: "k8s-metadata-kafka-bridge-pub-pre-prod-infraprod"
         - name: CONSUMER_AUTOCOMMIT_ENABLE
-          value: "false"
+          value: "true"
         - name: TOPIC
-          value: "NativeCmsPublicationEvents"
+          value: "PreNativeCmsMetadataPublicationEvents"
         - name: PRODUCER_HOST
           valueFrom:
             configMapKeyRef:
@@ -67,9 +67,9 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: cms-kafka-bridge-pub-pre-prod
+  name: cms-metadata-kafka-bridge-pub-pre-prod
   labels:
-    app: cms-kafka-bridge-pub-pre-prod
+    app: cms-metadata-kafka-bridge-pub-pre-prod
     visualize: "true"
     hasHealthcheck: "true"
 spec:
@@ -77,5 +77,5 @@ spec:
     - port: 8080
       targetPort: 8080
   selector:
-    app: cms-kafka-bridge-pub-pre-prod
+    app: cms-metadata-kafka-bridge-pub-pre-prod
 

--- a/pub-kube-config-files/concepts-kafka-bridge-pub-pre-prod.yaml
+++ b/pub-kube-config-files/concepts-kafka-bridge-pub-pre-prod.yaml
@@ -1,43 +1,42 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: cms-metadata-kafka-bridge-pub-pre-prod
+  name: concepts-kafka-bridge-pub-pre-prod
   labels:
-    app: cms-metadata-kafka-bridge-pub-pre-prod
+    app: concepts-kafka-bridge-pub-pre-prod
     visualize: "true"
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
-      app: cms-metadata-kafka-bridge-pub-pre-prod
+      app: concepts-kafka-bridge-pub-pre-prod
   template:
     metadata:
       labels:
-        app: cms-metadata-kafka-bridge-pub-pre-prod
+        app: concepts-kafka-bridge-pub-pre-prod
         visualize: "true"
     spec:
       containers:
-      - name: cms-metadata-kafka-bridge-pre-prod
-        image:  coco/coco-kafka-bridge:remove-host-based-routing-rc2
+      - name: concepts-kafka-bridge-pub-pre-prod
+        image:  coco/coco-kafka-bridge:14.2.0-k8s-removed-host-based-routing-rc.2
+        imagePullPolicy: Always
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: certificates-storage
         env:
         - name: QUEUE_PROXY_ADDRS
-          value: "https://pub-pre-prod-uk-up.ft.com/__kafka-rest-proxy"
+          value: "https://pub-pre-prod-up.ft.com/__kafka-rest-proxy"
         - name: GROUP_ID
-          value: "k8s-metadata-kafka-bridge-pub-pre-prod-infraprod"
+          value: "k8s-concepts-kafka-bridge-pub-pre-prod-infraprod"
         - name: CONSUMER_AUTOCOMMIT_ENABLE
           value: "true"
         - name: TOPIC
-          value: "NativeCmsMetadataPublicationEvents"
+          value: "Concept"
         - name: PRODUCER_HOST
           valueFrom:
             configMapKeyRef:
               name: global-config
               key: kafka.proxy.url.with.protocol
-        - name: PRODUCER_HOST_HEADER
-          value: "kafka-proxy"
         - name: PRODUCER_TYPE
           value: "proxy"
         - name: AUTHORIZATION_KEY
@@ -67,9 +66,9 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: cms-metadata-kafka-bridge-pub-pre-prod
+  name: concepts-kafka-bridge-pub-pre-prod
   labels:
-    app: cms-metadata-kafka-bridge-pub-pre-prod
+    app: concepts-kafka-bridge-pub-pre-prod
     visualize: "true"
     hasHealthcheck: "true"
 spec:
@@ -77,5 +76,5 @@ spec:
     - port: 8080
       targetPort: 8080
   selector:
-    app: cms-metadata-kafka-bridge-pub-pre-prod
+    app: concepts-kafka-bridge-pub-pre-prod
 

--- a/pub-kube-config-files/kafka.yaml
+++ b/pub-kube-config-files/kafka.yaml
@@ -140,3 +140,20 @@ spec:
       targetPort: 2181
   selector:
     app: kafka
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: kafka-rest-proxy
+  labels:
+    app: kafka-rest-proxy
+    visualize: "true"
+spec:
+  ports:
+    - port: 8080
+      name: "kafka-proxy-access-from-varnish"
+      targetPort: 8082
+  selector:
+    app: kafka


### PR DESCRIPTION
- pub cluster now connected to pub-pre-prod, delivery to pub
- updated bridges to latest k8s version
- created another service for kafka to expose the kafka-proxy on the endpoint where varnish expects it to be