### PR TITLE
Fix zk  persistence config and reconfigure logging to avoid spam

### DIFF
--- a/delivery-kube-config-files/kafka.yaml
+++ b/delivery-kube-config-files/kafka.yaml
@@ -85,6 +85,9 @@ spec:
            subPath: kafka-data
       - name: zookeeper
         image: wurstmeister/zookeeper
+        env:
+        - name: ZOO_LOG4J_PROP
+          value: "ERROR, CONSOLE"
         ports:
         - containerPort: 2181
         livenessProbe:
@@ -93,7 +96,7 @@ spec:
             port: 2181
         volumeMounts:
         - name: kafka-persistent-storage
-          mountPath: /opt/zookeeper-3.4.6/data
+          mountPath: /opt/zookeeper-3.4.9/data
           subPath: zk-data
       - name: kafka-proxy
         image: coco/kafka-proxy:v1.0.0

--- a/pub-kube-config-files/kafka.yaml
+++ b/pub-kube-config-files/kafka.yaml
@@ -85,6 +85,9 @@ spec:
            subPath: kafka-data
       - name: zookeeper
         image: wurstmeister/zookeeper
+        env:
+        - name: ZOO_LOG4J_PROP
+          value: "ERROR, CONSOLE"
         ports:
         - containerPort: 2181
         livenessProbe:
@@ -93,7 +96,7 @@ spec:
             port: 2181
         volumeMounts:
         - name: kafka-persistent-storage
-          mountPath: /opt/zookeeper-3.4.6/data
+          mountPath: /opt/zookeeper-3.4.9/data
           subPath: zk-data
       - name: kafka-proxy
         image: coco/kafka-proxy:v1.0.0


### PR DESCRIPTION
- wanted to also version zk but there is no versioned image for 3.4.9... https://hub.docker.com/r/wurstmeister/zookeeper/builds/
- logging config based on zk sources:
https://github.com/apache/zookeeper/blob/ec20c5434cc8a334b3fd25e27d26dccf4793c8f3/bin/zkEnv.sh#L73
- zk was logging 100K+ messages / minute, now it's down to 0