### PR TITLE
Increased kafka volumes to 50 GB

### DIFF
--- a/ansible/tasks/provision/delivery.yaml
+++ b/ansible/tasks/provision/delivery.yaml
@@ -6,7 +6,7 @@
     region: "{{ region }}"
     zone: "{{ region }}a"
     name: "{{ stack_name }}-kafka"
-    volume_size: 10
+    volume_size: 50
     volume_type: gp2
     tags:
       environment: "{{ environment_type }}"

--- a/ansible/tasks/provision/publishing.yaml
+++ b/ansible/tasks/provision/publishing.yaml
@@ -42,7 +42,7 @@
     region: "{{ region }}"
     zone: "{{ region }}a"
     name: "{{ stack_name }}-kafka"
-    volume_size: 10
+    volume_size: 50
     volume_type: gp2
     tags:
       environment: "{{ environment_type }}"


### PR DESCRIPTION
The max currently in any env is 20GB used by kafka + zookeeper. We thought of 50GB should cover also the scenarios when we'll have peaks.