### PR TITLE
Delete the S3 bucket for splunk provisioning stuff

### DIFF
--- a/ansible/decom.yaml
+++ b/ansible/decom.yaml
@@ -94,11 +94,3 @@
         - "{{ stack_name }}-imagepublish"
         - "{{ stack_name }}-genericrw"
       when: (cluster_environment | lower == "delivery")
-
-    - name: Delete the S3 bucket for Splunk 
-      s3_bucket:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        region: "{{ region }}"
-        name: "splunklogs-{{ stack_name }}"
-        state: absent 

--- a/ansible/provision.yaml
+++ b/ansible/provision.yaml
@@ -95,15 +95,3 @@
 
     - include: tasks/provision/neo4j.yaml
       when: (cluster_environment | lower == "neo4j")
-
-    - name: Create an S3 bucket for Splunk logs
-      s3_bucket:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        region: "{{ region }}"
-        name: "splunklogs-{{ stack_name }}"
-        state: present
-        tags:
-          environment: "{{ environment_type}} "
-          teamDL: "universal.publishing.platform@ft.com"
-          systemCode: "{{ platform }}"


### PR DESCRIPTION
We are not using a S3 bucket to drain splunk logs 
So get rid of it from the provisioner