### PR TITLE
increase the size of the mongodb ebs volumes

### DIFF
--- a/ansible/tasks/provision/publishing.yaml
+++ b/ansible/tasks/provision/publishing.yaml
@@ -59,7 +59,7 @@
     region: "{{ region }}"
     zone: "{{ item }}"
     name: "{{ stack_name }}-mongo-{{ item }}"
-    volume_size: 350
+    volume_size: 500
     volume_type: gp2
     tags:
       environment: "{{ environment_type }}"


### PR DESCRIPTION
The ebs volume for mongodb on the prod-publish-eu cluster ran out of disk space. So we are manually increasing them to 500GB.

So making sure the manual change in reflected in the provisioner