### PR TITLE
Logfilter update - filtering based on service name

### DIFF
--- a/ansible/templates/cluster-template.yaml.j2
+++ b/ansible/templates/cluster-template.yaml.j2
@@ -292,7 +292,7 @@ controller:
       [Service]
       EnvironmentFile=/etc/etcd-environment
       Environment="DOCKER_LOG_COLLECTOR_VERSION=1.0.0"
-      Environment="DOCKER_LOGFILTER_VERSION=1.3.0"
+      Environment="DOCKER_LOGFILTER_VERSION=1.3.1"
       TimeoutStartSec=1200
       # Change killmode from "control-group" to "none" to let Docker remove
       # work correctly.
@@ -725,7 +725,7 @@ worker:
           [Service]
           EnvironmentFile=/etc/etcd-environment
           Environment="DOCKER_LOG_COLLECTOR_VERSION=1.0.0"
-          Environment="DOCKER_LOGFILTER_VERSION=1.3.0"
+          Environment="DOCKER_LOGFILTER_VERSION=1.3.1"
           TimeoutStartSec=1200
           # Change killmode from "control-group" to "none" to let Docker remove
           # work correctly.


### PR DESCRIPTION
Fix for `resilient-splunk-forwarder` issues.

Please see https://github.com/Financial-Times/coco-logfilter/releases/tag/1.3.1