### PR TITLE
Limiting the AZs for the publishing cluster

### DIFF
--- a/ansible/vars/platform_configs/upp-d-publish-eu.yaml
+++ b/ansible/vars/platform_configs/upp-d-publish-eu.yaml
@@ -10,7 +10,7 @@ etcd_count: 3
 
 # Worker Instance Properties
 worker_pools: 
-  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 3}
+  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
   - {id: 2, instance_type: m4.large, count: 3, role: mongo-worker, subnets: 3, dedicatedtaint: mongo}
   - {id: 3, instance_type: c4.xlarge, count: 1, role: kafka-worker, subnets: 1, dedicatedtaint: kafka}
 

--- a/ansible/vars/platform_configs/upp-p-publish-eu.yaml
+++ b/ansible/vars/platform_configs/upp-p-publish-eu.yaml
@@ -10,7 +10,7 @@ etcd_count: 3
 
 # Worker Instance Properties
 worker_pools: 
-  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 3}
+  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
   - {id: 2, instance_type: m4.large, count: 3, role: mongo-worker, subnets: 3, dedicatedtaint: mongo}
   - {id: 3, instance_type: c4.xlarge, count: 1, role: kafka-worker, subnets: 1, dedicatedtaint: kafka}
 

--- a/ansible/vars/platform_configs/upp-p-publish-us.yaml
+++ b/ansible/vars/platform_configs/upp-p-publish-us.yaml
@@ -10,7 +10,7 @@ etcd_count: 3
 
 # Worker Instance Properties
 worker_pools: 
-  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 3}
+  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
   - {id: 2, instance_type: m4.large, count: 3, role: mongo-worker, subnets: 3, dedicatedtaint: mongo}
   - {id: 3, instance_type: c4.xlarge, count: 1, role: kafka-worker, subnets: 1, dedicatedtaint: kafka}
 

--- a/ansible/vars/platform_configs/upp-t-publish-eu.yaml
+++ b/ansible/vars/platform_configs/upp-t-publish-eu.yaml
@@ -10,7 +10,7 @@ etcd_count: 3
 
 # Worker Instance Properties
 worker_pools: 
-  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 3}
+  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
   - {id: 2, instance_type: m4.large, count: 3, role: mongo-worker, subnets: 3, dedicatedtaint: mongo}
   - {id: 3, instance_type: c4.xlarge, count: 1, role: kafka-worker, subnets: 1, dedicatedtaint: kafka}
 

--- a/ansible/vars/platform_configs/upp-t-publish-us.yaml
+++ b/ansible/vars/platform_configs/upp-t-publish-us.yaml
@@ -9,8 +9,8 @@ etcd_instance_type: t2.medium
 etcd_count: 3
 
 # Worker Instance Properties
-worker_pools: 
-  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 3}
+worker_pools:
+  - {id: 1, instance_type: m4.xlarge, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
   - {id: 2, instance_type: m4.large, count: 3, role: mongo-worker, subnets: 3, dedicatedtaint: mongo}
   - {id: 3, instance_type: c4.xlarge, count: 1, role: kafka-worker, subnets: 1, dedicatedtaint: kafka}
 


### PR DESCRIPTION
We're doing this because we only have 2 nodes in publish and we want to rely on which zones are used for the nodes, for EBS provisioning