### PR TITLE
Limiting the AZs for the pac cluster

### DIFF
--- a/ansible/vars/platform_configs/pac-d-eu.yaml
+++ b/ansible/vars/platform_configs/pac-d-eu.yaml
@@ -10,7 +10,7 @@ etcd_count: 3
 
 # Worker Instance Properties
 worker_pools: 
-  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 3}
+  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
 
 worker_security_groups:
   - sg-9a7630e2

--- a/ansible/vars/platform_configs/pac-p-eu.yaml
+++ b/ansible/vars/platform_configs/pac-p-eu.yaml
@@ -10,7 +10,7 @@ etcd_count: 3
 
 # Worker Instance Properties
 worker_pools:
-  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 3}
+  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
 
 worker_security_groups:
   - sg-17f58d6e

--- a/ansible/vars/platform_configs/pac-p-us.yaml
+++ b/ansible/vars/platform_configs/pac-p-us.yaml
@@ -10,7 +10,7 @@ etcd_count: 3
 
 # Worker Instance Properties
 worker_pools:
-  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 3}
+  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
 
 worker_security_groups:
   - sg-f1ec2b82

--- a/ansible/vars/platform_configs/pac-t-eu.yaml
+++ b/ansible/vars/platform_configs/pac-t-eu.yaml
@@ -10,7 +10,7 @@ etcd_count: 3
 
 # Worker Instance Properties
 worker_pools:
-  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 3}
+  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
 
 worker_security_groups:
   - sg-17f58d6e

--- a/ansible/vars/platform_configs/pac-t-us.yaml
+++ b/ansible/vars/platform_configs/pac-t-us.yaml
@@ -10,7 +10,7 @@ etcd_count: 3
 
 # Worker Instance Properties
 worker_pools:
-  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 3}
+  - {id: 1, instance_type: t2.large, count: 2, role: worker, subnets: 2} # using only 2 subnets to have nodes only in AZ a and b
 
 worker_security_groups:
   - sg-f1ec2b82


### PR DESCRIPTION
Since we only have 2 nodes and we want to rely on which zones are used, for EBS provisioning.