### PR TITLE
Increased the sysctl property fs.inotify.max_user_instances for workers.

### DIFF
--- a/ansible/templates/cluster-template.yaml.j2
+++ b/ansible/templates/cluster-template.yaml.j2
@@ -656,6 +656,10 @@ worker:
           net.ipv4.tcp_keepalive_time=30
           net.ipv4.tcp_keepalive_probes=4
           net.ipv4.tcp_keepalive_intvl=5
+      - path: /etc/sysctl.d/91-inotify-max.conf
+        permissions: 0644
+        content: |
+          fs.inotify.max_user_instances=256
 
       - path: /etc/systemd/system/docker.service.d/99-docker-opts-override.conf
         permissions: 0644


### PR DESCRIPTION
This is to prevent the "Too many open files" error appearing when trying to look in the logs with kubectl.