### PR TITLE
Set tiller history limit

### DIFF
--- a/ansible/userdata/cloud-config-controller
+++ b/ansible/userdata/cloud-config-controller
@@ -4349,6 +4349,8 @@ write_files:
               - env:
                 - name: TILLER_NAMESPACE
                   value: kube-system
+                - name: TILLER_HISTORY_MAX
+                  value: "5"
                 image: {{.TillerImage.RepoWithTag}}
                 imagePullPolicy: IfNotPresent
                 livenessProbe:


### PR DESCRIPTION
- limit the maximum number of releases kept for every service (`helm history {service}`)
- is only applied to existing services when the service is deployed
- tested in dev publish