### PR TITLE
Add cronjobs to backup and restore scripts

### DIFF
--- a/ansible/userdata/cloud-config-controller
+++ b/ansible/userdata/cloud-config-controller
@@ -2133,7 +2133,7 @@ write_files:
                       RESOURCES_IN_NAMESPACE="componentstatuses configmaps daemonsets deployments endpoints events horizontalpodautoscalers
                       ingresses jobs limitranges networkpolicies  persistentvolumeclaims pods podsecuritypolicies podtemplates replicasets
                       replicationcontrollers resourcequotas secrets serviceaccounts services statefulsets customresourcedefinitions
-                      poddisruptionbudgets roles rolebindings";
+                      poddisruptionbudgets roles rolebindings cronjobs";
                       for ns in $(jq -r '.items[].metadata.name' < ${DUMP_DIR}/namespaces.json);do
                         echo "Searching in namespace: ${ns}" ;
                         mkdir -p ${DUMP_DIR}/${ns} ;

--- a/sh/restore.sh
+++ b/sh/restore.sh
@@ -95,7 +95,7 @@ main() {
     RESTORATION_ORDER_NS=( persistentvolumeclaims configmaps endpoints ingresses jobs limitranges networkpolicies
                         podsecuritypolicies podtemplates resourcequotas secrets serviceaccounts services thirdpartyresources
                         horizontalpodautoscalers pods replicasets replicationcontrollers daemonsets deployments statefulsets
-                        poddisruptionbudgets roles rolebindings)
+                        poddisruptionbudgets roles rolebindings cronjobs)
 
     preFlightChecks "${@}"
     AWS_BUCKET="${1}"; shift


### PR DESCRIPTION
- the [backup](https://github.com/kubernetes-incubator/kube-aws/blob/master/builtin/files/userdata/cloud-config-controller#L2140-L2257) and [restore](https://github.com/kubernetes-incubator/kube-aws/blob/master/contrib/cluster-backup/restore.sh) scripts come from the [kube-aws repo](https://github.com/kubernetes-incubator/kube-aws)
- for some reason, `cronjob` resources are not backed up, or restored - **I don't know if this is intentional or accidental**, I haven't found any issues or commits on this subject
- I added the cronjob resources to our backup & restore scripts and tried it out:
  - changed the `kube-resources-autosave` deployment in place to back up cronjobs, which triggered a backup
  - confirmed that the `cronjob` resources were on S3
  - deleted cronjobs in dev delivery
  - ran the changed restore scripts, changed to only restore cronjobs, and it restored them
