### PR TITLE
Provision Thanos EBSes

### DIFF
--- a/ansible/decom.yaml
+++ b/ansible/decom.yaml
@@ -80,6 +80,15 @@
         VOLUME_NAME: "{{ stack_name }}-prometheus"
       when: (platform | lower == "pac" or cluster_environment | lower == "publish" or cluster_environment | lower == "delivery")
 
+    - name: Delete persistent volume for Thanos
+      script: /bin/bash /delete-volumes.sh
+      environment:
+        AWS_REGION: "{{ region }}"
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+        VOLUME_NAME: "{{ stack_name }}-thanos-store"
+      when: (platform | lower == "pac" or cluster_environment | lower == "publish" or cluster_environment | lower == "delivery")
+
     - name: Delete the S3 bucket for Image Publish and generic RW
       s3_bucket:
         aws_access_key: "{{ aws_access_key }}"

--- a/ansible/tasks/provision/delivery.yaml
+++ b/ansible/tasks/provision/delivery.yaml
@@ -51,6 +51,21 @@
     - "{{ region }}b"
   register: ec2_vol_del_prometheus
 
+- name: Provision EBS volume for Thanos
+  ec2_vol:
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_access_key }}"
+    region: "{{ region }}"
+    zone: "{{ region }}a"
+    name: "{{ stack_name }}-thanos-store"
+    volume_size: 50
+    volume_type: gp2
+    tags:
+      environment: "{{ environment_type }}"
+      teamDL: "universal.publishing.platform@ft.com"
+      systemCode: "{{ platform }}"
+  register: ec2_vol_del_thanos
+
 - name: Generate the S3 bucket policy for Image Publish
   template:
     src: templates/image-publish-s3.json.j2
@@ -161,6 +176,10 @@
   set_fact:
     prometheus_volume_info: "{{ prometheus_volume_info }} + [ '{{ item.volume.zone}} => {{ item.volume_id }}' ]"
   with_items: "{{ ec2_vol_del_prometheus.results }}"
+
+- name: EBS volume details for Thanos
+  debug:
+    msg: "EBS Volume ID for Thanos: '{{ ec2_vol_del_thanos.volume_id }}'"
 
 - name: EBS details for Neo4j volumes
   debug:

--- a/ansible/tasks/provision/delivery.yaml
+++ b/ansible/tasks/provision/delivery.yaml
@@ -87,6 +87,7 @@
   s3_bucket:
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_access_key }}"
+    region: "{{ region }}"
     name: "{{ stack_name }}-imagepublish"
     policy: "{{ lookup('file','templates/image-publish-s3.json') }}"
 
@@ -172,6 +173,10 @@
   with_items: "{{ ec2_vol_del_mongo.results }}"
 
 # Volume IDs for Prometheus which needs to be added in the config
+- name: Setup vol names
+  set_fact:
+    prometheus_volume_info: []
+
 - name: EBS details for Prometheus
   set_fact:
     prometheus_volume_info: "{{ prometheus_volume_info }} + [ '{{ item.volume.zone}} => {{ item.volume_id }}' ]"

--- a/ansible/tasks/provision/pac.yaml
+++ b/ansible/tasks/provision/pac.yaml
@@ -17,8 +17,28 @@
     - "{{ region }}b"
   register: ec2_vol_pac_prometheus
 
+- name: Provision EBS volume for Thanos
+  ec2_vol:
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_access_key }}"
+    region: "{{ region }}"
+    zone: "{{ region }}a"
+    name: "{{ stack_name }}-thanos-store"
+    volume_size: 50
+    volume_type: gp2
+    tags:
+      environment: "{{ environment_type }}"
+      teamDL: "universal.publishing.platform@ft.com"
+      systemCode: "{{ platform }}"
+  register: ec2_vol_pac_thanos
+
 # Volume IDs for Prometheus which needs to be added in the config
 - name: EBS details for Prometheus
   set_fact:
     prometheus_volume_info: "{{ prometheus_volume_info }} + [ '{{ item.volume.zone}} => {{ item.volume_id }}' ]"
   with_items: "{{ ec2_vol_pac_prometheus.results }}"
+
+- name: EBS volume details for Thanos
+  debug:
+    msg: "EBS Volume ID for Thanos: '{{ ec2_vol_pac_thanos.volume_id }}'"
+

--- a/ansible/tasks/provision/pac.yaml
+++ b/ansible/tasks/provision/pac.yaml
@@ -33,6 +33,10 @@
   register: ec2_vol_pac_thanos
 
 # Volume IDs for Prometheus which needs to be added in the config
+- name: Setup vol names
+  set_fact:
+    prometheus_volume_info: []
+
 - name: EBS details for Prometheus
   set_fact:
     prometheus_volume_info: "{{ prometheus_volume_info }} + [ '{{ item.volume.zone}} => {{ item.volume_id }}' ]"

--- a/ansible/tasks/provision/publishing.yaml
+++ b/ansible/tasks/provision/publishing.yaml
@@ -85,6 +85,10 @@
     msg: "{{ mongo_volume_info }}"
 
 # Volume IDs for Prometheus which needs to be added in the config
+- name: Setup vol names
+  set_fact:
+    prometheus_volume_info: []
+
 - name: EBS details for Prometheus
   set_fact:
     prometheus_volume_info: "{{ prometheus_volume_info }} + [ '{{ item.volume.zone}} => {{ item.volume_id }}' ]"

--- a/ansible/tasks/provision/publishing.yaml
+++ b/ansible/tasks/provision/publishing.yaml
@@ -51,6 +51,21 @@
     - "{{ region }}b"
   register: ec2_vol_pub_prometheus
 
+- name: Provision EBS volume for Thanos
+  ec2_vol:
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_access_key }}"
+    region: "{{ region }}"
+    zone: "{{ region }}a"
+    name: "{{ stack_name }}-thanos-store"
+    volume_size: 50
+    volume_type: gp2
+    tags:
+      environment: "{{ environment_type }}"
+      teamDL: "universal.publishing.platform@ft.com"
+      systemCode: "{{ platform }}"
+  register: ec2_vol_pub_thanos
+
 # File System  and Volume ID's for Kafka and Mongo which needs to be added in the global config
 - name: Setup vol names
   set_fact:
@@ -74,3 +89,7 @@
   set_fact:
     prometheus_volume_info: "{{ prometheus_volume_info }} + [ '{{ item.volume.zone}} => {{ item.volume_id }}' ]"
   with_items: "{{ ec2_vol_pub_prometheus.results }}"
+
+- name: EBS volume details for Thanos
+  debug:
+    msg: "EBS Volume ID for Thanos: '{{ ec2_vol_pub_thanos.volume_id }}'"


### PR DESCRIPTION
Prior to this change, there are no Thanos EBS provisioning tasks. The ones in use were created manually. This change adds tasks to provision Thanos EBSes during initial cluster creation.

Jira: https://jira.ft.com/browse/CPH-37
TODO:
- [x] This change needs to be tested before merging into master