### PR TITLE
Set k8s-cli-utils release to 1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Using kube-aws 0.10
-FROM coco/k8s-cli-utils:kube-aws-version-update
+FROM coco/k8s-cli-utils:1.3.0
 
 ENV ANSIBLE_HOSTS=/ansible/hosts
 


### PR DESCRIPTION
k8s-cli-utils was used from a branch. the kube-aws-version-update branch is now merged and released under release 1.3.0.

More details here:
https://github.com/Financial-Times/k8s-cli-utils/pull/10
https://financialtimes.slack.com/archives/C96U2ERJL/p1563957876035900
https://jira.ft.com/browse/CPH-140
