### PR TITLE
Make the domain zone configurable

### DIFF
--- a/ansible/reprovision-k8s-only.yaml
+++ b/ansible/reprovision-k8s-only.yaml
@@ -95,7 +95,7 @@
       tags: k-prov
 
     - pause:
-        prompt: "Check that the API server EC2 instances have been created, and that {{ stack_name }}-api.ft.com resolves to the correct load balancer. (Enter to continue or Ctrl+C to abort)"
+        prompt: "Check that the API server EC2 instances have been created, and that {{ stack_name }}-api.{{ dns_zone }} resolves to the correct load balancer. (Enter to continue or Ctrl+C to abort)"
 
     - name: Make default account admin
       shell: |

--- a/ansible/tasks/create_cname.yaml
+++ b/ansible/tasks/create_cname.yaml
@@ -10,7 +10,7 @@
     headers:
       X-API-Key: "{{ konstructor_api_key }}"
     body:
-      zone: ft.com
+      zone: "{{ dns_zone }}"
       name: "{{ dns_cname }}"
       rdata: "{{ hostname }}"
       ttl: "300"

--- a/ansible/tasks/delete_cname.yaml
+++ b/ansible/tasks/delete_cname.yaml
@@ -10,7 +10,7 @@
     headers:
       X-API-Key: "{{ konstructor_api_key }}"
     body:
-      zone: ft.com
+      zone: "{{ dns_zone }}"
       name: "{{ dns_cname }}"
       emailAddress: "universal.publishing.platform@ft.com"
     body_format: json

--- a/ansible/templates/cluster-template.yaml.j2
+++ b/ansible/templates/cluster-template.yaml.j2
@@ -64,7 +64,7 @@ apiEndpoints:
   # below if you'd like kube-aws to create a Route53 record sets/hosted zones
   # for you.  Otherwise the deployer is responsible for making this name routable
 
-  dnsName: {{ stack_name }}-api.ft.com
+  dnsName: {{ stack_name }}-api.{{ dns_zone }}
 
   # Configuration for the load balancer serving this endpoint
   # Omit all the settings when you want kube-aws not to provision a load balancer for you

--- a/ansible/templates/kubeconfig.yaml.j2
+++ b/ansible/templates/kubeconfig.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority: /ansible/credentials/ca.pem
-    server: https://{{ stack_name }}-api.ft.com
+    server: https://{{ stack_name }}-api.{{ dns_zone }}
   name: kube-aws-cluster
 contexts:
 - context:

--- a/ansible/vars/account_configs/d-eu.yaml
+++ b/ansible/vars/account_configs/d-eu.yaml
@@ -22,3 +22,4 @@ vpc_internal_ssh_sg: sg-9a7630e2
 api_private_access_sg: sg-53531d2b
 efs_access_sg: sg-c76f91bc
 
+dns_zone: ft.com

--- a/ansible/vars/account_configs/p-eu.yaml
+++ b/ansible/vars/account_configs/p-eu.yaml
@@ -21,3 +21,5 @@ efs_access_sg: sg-a6e41cdd
 worker_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-worker-role
 etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-etcd-role
 controller_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-controller-role
+
+dns_zone: ft.com

--- a/ansible/vars/account_configs/p-us.yaml
+++ b/ansible/vars/account_configs/p-us.yaml
@@ -21,3 +21,5 @@ efs_access_sg: sg-ba8ef4c8
 controller_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-controller-role
 etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-etcd-role
 worker_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-worker-role
+
+dns_zone: ft.com

--- a/ansible/vars/account_configs/t-eu.yaml
+++ b/ansible/vars/account_configs/t-eu.yaml
@@ -21,3 +21,5 @@ efs_access_sg: sg-a6e41cdd
 worker_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-worker-role
 etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-etcd-role
 controller_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-controller-role
+
+dns_zone: ft.com

--- a/ansible/vars/account_configs/t-us.yaml
+++ b/ansible/vars/account_configs/t-us.yaml
@@ -21,3 +21,5 @@ efs_access_sg: sg-ba8ef4c8
 controller_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-controller-role
 etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-etcd-role
 worker_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-worker-role
+
+dns_zone: ft.com


### PR DESCRIPTION
As part of the DNS migration we need to be able to configure the DNS zone in the provisioner. This PR adds `dns_zone` variable that is passed to the Konstructor and determines in which zone the K8S API LB will have a DNS record.