### PR TITLE
Change the dns zone for the staging clusters

### DIFF
--- a/ansible/vars/account_configs/t-eu.yaml
+++ b/ansible/vars/account_configs/t-eu.yaml
@@ -23,4 +23,4 @@ worker_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-pro
 etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-etcd-role
 controller_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-controller-role
 
-dns_zone: ft.com
+dns_zone: upp.ft.com

--- a/ansible/vars/account_configs/t-us.yaml
+++ b/ansible/vars/account_configs/t-us.yaml
@@ -23,4 +23,4 @@ controller_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance
 etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-etcd-role
 worker_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-worker-role
 
-dns_zone: ft.com
+dns_zone: upp.ft.com


### PR DESCRIPTION
This change sets the dns_zone to upp.ft.com. After this change is merged
the provisioner will create API CNAMEs in the upp.ft.com zone