### PR TITLE
Add Route53 cname creation tasks

### DIFF
--- a/ansible/decom.yaml
+++ b/ansible/decom.yaml
@@ -32,6 +32,34 @@
       vars:
         dns_cname: "{{ stack_name }}-api"
 
+    - name: Retrieve the Cluster API server ELB
+      script: /bin/bash /ansible/files/sh/get_elb.sh
+      environment:
+        AWS_REGION: "{{ region }}"
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+        CLUSTER_NAME: "{{ stack_name }}"
+      register: api_server_elb
+      tags: k-prov
+
+    - name: Delete the DNS entry for the API Server in Route53
+      script: /bin/bash /ansible/files/sh/manage-cname.sh
+      environment:
+        AWS_REGION: "{{ region }}"
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+        CNAME_ACTION: "DELETE"
+        DNS_ZONE: "{{ dns_zone }}"
+        HOSTED_ZONE_ID: "{{ route53_hosted_zone_id }}"
+        API_DOMAIN_NAME: "{{ stack_name }}-api"
+        LB_FQDN: "{{ api_server_elb.stdout }}"
+      register: manage_cname_output
+      tags: k-prov
+
+    - name: Output manage-cname.sh log
+      debug:
+        msg: "{{ manage_cname_output }}"
+
     - name: Decom an EFS instances (Transformers cache and Factset reader)
       efs:
         state: absent

--- a/ansible/files/sh/manage-cname.sh
+++ b/ansible/files/sh/manage-cname.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+COMMENT="Auto change action $CNAME_ACTION @ $(date) from the content-k8s-provisioner"
+API_FQDN="${API_DOMAIN_NAME}.${DNS_ZONE}"
+
+echo "DEBUG: variable and values:"
+echo "Action: $CNAME_ACTION"
+echo "Hosted zone: $HOSTED_ZONE_ID"
+echo "Domain name: $API_DOMAIN_NAME"
+echo "DNS zone: $DNS_ZONE"
+echo "Name: $API_FQDN"
+echo "LB FQDN: $LB_FQDN"
+
+
+echo "Assume the Route53 DNS prod role"
+aws_sts_assume_role=$(aws sts assume-role \
+  --role-arn "arn:aws:iam::345152836601:role/route53-iam-dnsonlyroleuppprodE94AAA36-CAPB27QPX3K8" \
+  --role-session-name "content-k8s-provisioner-session"
+)
+
+export AWS_ACCESS_KEY_ID=$(echo $aws_sts_assume_role | jq -r .Credentials.AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo $aws_sts_assume_role | jq -r .Credentials.SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo $aws_sts_assume_role | jq -r .Credentials.SessionToken)
+
+aws sts get-caller-identity
+
+echo "Generate change set file..."
+TMPFILE=$(mktemp /tmp/temporary-file.XXXXXXXX)
+cat > ${TMPFILE} << EOF
+    {
+      "Comment":"$COMMENT",
+      "Changes":[
+        {
+          "Action":"$CNAME_ACTION",
+          "ResourceRecordSet":{
+            "ResourceRecords":[
+              {
+                "Value":"$LB_FQDN"
+              }
+            ],
+            "Name":"$API_FQDN",
+            "Type":"CNAME",
+            "TTL": 30
+          }
+        }
+      ]
+    }
+EOF
+
+cat "$TMPFILE"
+
+
+echo "Change record set..."
+aws route53 change-resource-record-sets \
+    --hosted-zone-id "$HOSTED_ZONE_ID" \
+    --change-batch file://"$TMPFILE"
+
+rm "$TMPFILE"
+
+echo "Done."

--- a/ansible/provision.yaml
+++ b/ansible/provision.yaml
@@ -66,6 +66,24 @@
         hostname: "{{ api_server_elb.stdout }}"
       tags: k-prov
 
+    - name: Create a DNS entry for the API Server in Route53
+      script: /bin/bash /ansible/files/sh/manage-cname.sh
+      environment:
+        AWS_REGION: "{{ region }}"
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+        CNAME_ACTION: "UPSERT"
+        DNS_ZONE: "{{ dns_zone }}"
+        HOSTED_ZONE_ID: "{{ route53_hosted_zone_id }}"
+        API_DOMAIN_NAME: "{{ stack_name }}-api"
+        LB_FQDN: "{{ api_server_elb.stdout }}"
+      register: manage_cname_output
+      tags: k-prov
+
+    - name: Output manage-cname.sh log
+      debug:
+        msg: "{{ manage_cname_output }}"
+
     - name: Create prometheus S3 bucket
       cloudformation:
         stack_name: "{{ stack_name }}-prometheus-s3"

--- a/ansible/reprovision-k8s-only.yaml
+++ b/ansible/reprovision-k8s-only.yaml
@@ -94,6 +94,24 @@
         hostname: "{{ api_server_elb.stdout }}"
       tags: k-prov
 
+    - name: Create a DNS entry for the API Server in Route53
+      script: /bin/bash /ansible/files/sh/manage-cname.sh
+      environment:
+        AWS_REGION: "{{ region }}"
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"
+        CNAME_ACTION: "UPSERT"
+        DNS_ZONE: "{{ dns_zone }}"
+        HOSTED_ZONE_ID: "{{ route53_hosted_zone_id }}"
+        API_DOMAIN_NAME: "{{ stack_name }}-api"
+        LB_FQDN: "{{ api_server_elb.stdout }}"
+      register: manage_cname_output
+      tags: k-prov
+
+    - name: Output manage-cname.sh log
+      debug:
+        msg: "{{ manage_cname_output }}"
+
     - pause:
         prompt: "Check that the API server EC2 instances have been created, and that {{ stack_name }}-api.{{ dns_zone }} resolves to the correct load balancer. (Enter to continue or Ctrl+C to abort)"
 

--- a/ansible/vars/account_configs/d-eu.yaml
+++ b/ansible/vars/account_configs/d-eu.yaml
@@ -24,3 +24,4 @@ api_private_access_sg: sg-53531d2b
 efs_access_sg: sg-c76f91bc
 
 dns_zone: upp.ft.com
+route53_hosted_zone_id: ZE8P6HDQA4Y9N

--- a/ansible/vars/account_configs/p-eu.yaml
+++ b/ansible/vars/account_configs/p-eu.yaml
@@ -24,3 +24,4 @@ etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profi
 controller_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-controller-role
 
 dns_zone: upp.ft.com
+route53_hosted_zone_id: ZE8P6HDQA4Y9N

--- a/ansible/vars/account_configs/p-us.yaml
+++ b/ansible/vars/account_configs/p-us.yaml
@@ -24,3 +24,4 @@ etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profi
 worker_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-worker-role
 
 dns_zone: upp.ft.com
+route53_hosted_zone_id: ZE8P6HDQA4Y9N

--- a/ansible/vars/account_configs/t-eu.yaml
+++ b/ansible/vars/account_configs/t-eu.yaml
@@ -24,3 +24,4 @@ etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profi
 controller_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-controller-role
 
 dns_zone: upp.ft.com
+route53_hosted_zone_id: ZE8P6HDQA4Y9N

--- a/ansible/vars/account_configs/t-us.yaml
+++ b/ansible/vars/account_configs/t-us.yaml
@@ -24,3 +24,4 @@ etcd_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profi
 worker_iam_role: arn:aws:iam::469211898354:instance-profile/k8s-iam-instance-profile-roles-worker-role
 
 dns_zone: upp.ft.com
+route53_hosted_zone_id: ZE8P6HDQA4Y9N


### PR DESCRIPTION
This change adds the functionality to create/delete the API DNS records.